### PR TITLE
Fix signing issue

### DIFF
--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(OutDir)\Microsoft.Build.MSBuildLocator.dll">
+    <FilesToSign Include="$(OutDir)\Microsoft.Build.Locator.dll">
       <Authenticode>Microsoft</Authenticode>
     </FilesToSign>
   </ItemGroup>


### PR DESCRIPTION
Forgot to update MicroBuild's `FilesToSign` ItemGroup with the new assembly name.