### PR TITLE
Add check for PrivateAssets in PackageReference

### DIFF
--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -31,6 +31,10 @@
       <CopyToOutputDirectory>Never</CopyToOutputDirectory>
       <PackagePath>build\</PackagePath>
     </Content>
+    <Content Include="build\Microsoft.Build.Locator.targets">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+      <PackagePath>build\</PackagePath>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -19,6 +19,6 @@
     </ItemGroup>
     <Error
       Condition="'@(MSBuildPackagesWithoutPrivateAssets)' != ''"
-      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to all exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to true on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
+      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to all exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to all on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
   </Target>
 </Project>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -1,0 +1,24 @@
+﻿<Project>
+  <Target Name="EnsureMSBuildPrivateAssets" AfterTargets="Build" Condition="'$(DisableMSBuildPrivateAssetsCheck)' != 'true'">
+    <ItemGroup>
+      <MSBuildPackagesWithoutPrivateAssets
+        Include="@(PackageReference)"
+        Condition="
+          '%(PackageReference.PrivateAssets)' != 'all' and
+          (
+            '%(PackageReference.Identity)' == 'Microsoft.Build' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Framework' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Utilities.Core' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Tasks.Core' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Engine' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Conversion.Core' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Runtime' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Localization' or
+            '%(PackageReference.Identity)' == 'Microsoft.Build.Engine'
+          )"/>
+    </ItemGroup>
+    <Error
+      Condition="'@(MSBuildPackagesWithoutPrivateAssets)' != ''"
+      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to true exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application will load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to true on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
+  </Target>
+</Project>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -19,6 +19,6 @@
     </ItemGroup>
     <Error
       Condition="'@(MSBuildPackagesWithoutPrivateAssets)' != ''"
-      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to true exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application will load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to true on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
+      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to all exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to true on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
   </Target>
 </Project>


### PR DESCRIPTION
If you reference MSBuild packages by default it will copy implementation assemblies to your output folder. The consuming application will bind to this version of MSBuild at run-time.