### PR TITLE
Require ExcludeAssets=runtime on refs

### DIFF
--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -1,10 +1,10 @@
 ﻿<Project>
-  <Target Name="EnsureMSBuildPrivateAssets" AfterTargets="Build" Condition="'$(DisableMSBuildPrivateAssetsCheck)' != 'true'">
+  <Target Name="EnsureMSBuildAssembliesNotCopied" AfterTargets="Build" Condition="'$(DisableMSBuildAssemblyCopyCheck)' != 'true'">
     <ItemGroup>
       <MSBuildPackagesWithoutPrivateAssets
         Include="@(PackageReference)"
         Condition="
-          '%(PackageReference.PrivateAssets)' != 'all' and
+          '%(PackageReference.ExcludeAssets)' != 'runtime' and
           (
             '%(PackageReference.Identity)' == 'Microsoft.Build' or
             '%(PackageReference.Identity)' == 'Microsoft.Build.Framework' or
@@ -19,6 +19,6 @@
     </ItemGroup>
     <Error
       Condition="'@(MSBuildPackagesWithoutPrivateAssets)' != ''"
-      Text="A PackageReference to Microsoft.Build.* without PrivateAssets set to all exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at run-time. To use the copy associated with Visual Studio, set PrivateAssets to all on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildPrivateAssetsTest = true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
+      Text="A PackageReference to Microsoft.Build.* without ExcludeAssets=&quot;runtime&quot; exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at runtime. To use the copy of MSBuild registered by MSBuildLocator, set ExcludeAssets=&quot;runtime&quot; on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildAssemblyCopyCheck=true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
   </Target>
 </Project>


### PR DESCRIPTION
PrivateAssets controls the flow of dependencies between NuGet packages,
but not whether a given project copies package assets to its output
folder.

ExcludeAssets=runtime indicates that the runtime assets provided
(transitively, evidently) by the package should not be considered as
project outputs, which is what we want for this package: don't copy
MSBuild assemblies to your output.