### PR TITLE
Error if msbuild already loaded

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Build.Locator
             AppDomain.CurrentDomain.AssemblyResolve += (_, eventArgs) =>
             {
                 var assemblyName = new AssemblyName(eventArgs.Name);
-                if (s_msBuildAssemblies.Contains(assemblyName.Name, StringComparer.OrdinalIgnoreCase))
+                if (IsMSBuildAssembly(assemblyName))
                 {
                     var targetAssembly = Path.Combine(instance.MSBuildPath, assemblyName.Name + ".dll");
                     return File.Exists(targetAssembly) ? Assembly.LoadFrom(targetAssembly) : null;
@@ -77,6 +77,11 @@ namespace Microsoft.Build.Locator
 
                 return null;
             };
+        }
+
+        private static bool IsMSBuildAssembly(AssemblyName assemblyName)
+        {
+            return s_msBuildAssemblies.Contains(assemblyName.Name, StringComparer.OrdinalIgnoreCase);
         }
 
         private static IEnumerable<VisualStudioInstance> GetInstances()


### PR DESCRIPTION
The .NET assembly loader ensures that any assembly referenced by a
method is loaded before the method is called. This requires that
MSBuildLocator be called **before any method that references MSBuild**.

That's a confusing requirement, and easy to forget. But it's easy to
check for, and since we expect the locator to be called roughly once per
process, not too expensive to check for at `RegisterInstance` time.

Produces an error like

```
Unhandled Exception: System.InvalidOperationException: Microsoft.Build.Locator.MSBuildLocator.RegisterInstance was called, but MSBuild assemblies were already loaded.
Ensure that RegisterInstance is called before any method that directly references types in the Microsoft.Build namespace has been called.
Loaded MSBuild assemblies: Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
   at Microsoft.Build.Locator.MSBuildLocator.RegisterInstance(VisualStudioInstance instance)
   at Microsoft.Build.Locator.MSBuildLocator.RegisterDefaults()
   at MultiProcBuilderApplication.Program.Main(String[] args) in s:\work\MultiProcBuilderApplication\MultiProcBuilderApplication\Program.cs:line 13
```
