### PR TITLE
Add explanation for Builder class in example

### DIFF
--- a/samples/BuilderApp/Program.cs
+++ b/samples/BuilderApp/Program.cs
@@ -101,6 +101,8 @@ namespace BuilderApp
         }
     }
 
+    // Class for performing the project build
+    // The Microsoft.Build dlls needed from within aren't loaded until after the class is instantiated
     public class Builder
     {
         public bool Build(string projectFile)

--- a/samples/BuilderApp/Program.cs
+++ b/samples/BuilderApp/Program.cs
@@ -101,8 +101,15 @@ namespace BuilderApp
         }
     }
 
-    // Class for performing the project build
-    // The Microsoft.Build dlls needed from within aren't loaded until after the class is instantiated
+    /// <summary>
+    /// Class for performing the project build
+    /// </summary>
+    /// <remarks>
+    /// The Microsoft.Build namespaces must be referenced from a method that is called
+    /// after RegisterInstance so that it has a chance to change their load behavior.
+    /// Here, we put Microsoft.Build calls into a separate class
+    /// that is only referenced after calling RegisterInstance.
+    /// </remarks>
     public class Builder
     {
         public bool Build(string projectFile)


### PR DESCRIPTION
When implementing MSBuildLocator I originally called `MSBuildLocator.RegisterInstance()`, then later in the same function I called other Microsoft.Build functions. 

This is my first large project with a major C# component. I didn't know that all of the dll imports in my function would be loaded when the function was entered, instead of when the import procedures were called.

This request adds a short description above the Builder class to explain why it's necessary--so that the MSBuildLocator dll loads first, then after the appropriate setup is requested and the `Builder` class is instantiated can more Microsoft.Build dlls be loaded properly.