### PR TITLE
Report better version for VS preview consoles

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Build.Locator
                 Version version;
                 Version.TryParse(versionString, out version);
 
+                if (version == null && versionString.Contains('-'))
+                {
+                    versionString = versionString.Substring(0, versionString.IndexOf('-'));
+                    Version.TryParse(versionString, out version);
+                }
+
                 if (version == null)
                 {
                     versionString = Environment.GetEnvironmentVariable("VisualStudioVersion");


### PR DESCRIPTION
For prereleases, the Visual Studio command prompt sets the environment
variable `VSCMD_VER` to a value like `15.7.0-pre.3.0`, which is not
parseable by System.Version.

This could be handled by using a version parser that can handle this
SemVer 2 version as well as Windows 4-part versions, but that would be
another dependency, so I just special-cased the problematic dash.