### PR TITLE
Fix potential null-reference if "VSCMD_VER" is not set

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Build.Locator
                 Version version;
                 Version.TryParse(versionString, out version);
 
-                if (version == null && versionString.Contains('-'))
+                if (version == null && versionString?.Contains('-') == true)
                 {
                     versionString = versionString.Substring(0, versionString.IndexOf('-'));
                     Version.TryParse(versionString, out version);


### PR DESCRIPTION
In cases where "VSINSTALLDIR" is set but "VSCMD_VER" is not, getting the dev console instance could null-ref.