### PR TITLE
Register from path

### DIFF
--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net46</TargetFramework>
+    <TargetFramework>net47</TargetFramework>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net47</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/BuilderApp/Program.cs
+++ b/samples/BuilderApp/Program.cs
@@ -30,14 +30,14 @@ namespace BuilderApp
             // safely call code that use MSBuild types (in the Builder class).
             if (msbuildDeploymentToUse.VSInstance != null)
             {
-                Console.WriteLine($"Using MSBuild deployment from VS Instance: {msbuildDeploymentToUse.VSInstance.Name} - {msbuildDeploymentToUse.VSInstance.Version}");
+                Console.WriteLine($"Using MSBuild from VS Instance: {msbuildDeploymentToUse.VSInstance.Name} - {msbuildDeploymentToUse.VSInstance.Version}");
                 Console.WriteLine();
 
                 MSBuildLocator.RegisterInstance(msbuildDeploymentToUse.VSInstance);
             }
             else
             {
-                Console.WriteLine($"Using MSBuild deployment from path: {msbuildDeploymentToUse.MSBuildPath}");
+                Console.WriteLine($"Using MSBuild from path: {msbuildDeploymentToUse.MSBuildPath}");
                 Console.WriteLine();
 
                 MSBuildLocator.RegisterMSBuildPath(msbuildDeploymentToUse.MSBuildPath);

--- a/samples/BuilderApp/Program.cs
+++ b/samples/BuilderApp/Program.cs
@@ -24,14 +24,24 @@ namespace BuilderApp
             //   1) Use defaults and call: MSBuildLocator.RegisterDefaults();
             //   2) Do something fancier and ask the user. As an example we'll do that.
             var instances = MSBuildLocator.QueryVisualStudioInstances().ToList();
-            var instanceToUse = AskWhichVisualStudioInstanceToUse(instances);
+            var msbuildDeploymentToUse = AskWhichMSBuildToUse(instances);
 
-            // Calling RegisterInstance will subscribe to AssemblyResolve event. After this we can now
+            // Calling Register methods will subscribe to AssemblyResolve event. After this we can
             // safely call code that use MSBuild types (in the Builder class).
-            MSBuildLocator.RegisterInstance(instanceToUse);
+            if (msbuildDeploymentToUse.VSInstance != null)
+            {
+                Console.WriteLine($"Using MSBuild deployment from VS Instance: {msbuildDeploymentToUse.VSInstance.Name} - {msbuildDeploymentToUse.VSInstance.Version}");
+                Console.WriteLine();
 
-            Console.WriteLine($"Using VS Instance: {instanceToUse.Name} - {instanceToUse.Version}");
-            Console.WriteLine();
+                MSBuildLocator.RegisterInstance(msbuildDeploymentToUse.VSInstance);
+            }
+            else
+            {
+                Console.WriteLine($"Using MSBuild deployment from path: {msbuildDeploymentToUse.MSBuildPath}");
+                Console.WriteLine();
+
+                MSBuildLocator.RegisterMSBuildPath(msbuildDeploymentToUse.MSBuildPath);
+            }
 
             var result = new Builder().Build(projectFilePath);
             Console.WriteLine();
@@ -41,14 +51,14 @@ namespace BuilderApp
             Console.ResetColor();
         }
 
-        private static VisualStudioInstance AskWhichVisualStudioInstanceToUse(List<VisualStudioInstance> instances)
+        private static (VisualStudioInstance VSInstance, string MSBuildPath) AskWhichMSBuildToUse(List<VisualStudioInstance> instances)
         {
             if (instances.Count == 0)
             {
-                Console.WriteLine("MSBuild not found! Exiting.");
-                Environment.Exit(-1);
+                Console.WriteLine("No Visual Studio instances found!");
             }
 
+            Console.WriteLine($"0) Custom path");
             for (var i = 1; i <= instances.Count; i++)
             {
                 var instance = instances[i - 1];
@@ -65,11 +75,28 @@ namespace BuilderApp
             Console.WriteLine();
             Console.WriteLine("Select an instance of MSBuild: ");
             var answer = Console.ReadLine();
-            VisualStudioInstance instanceUsed = null;
 
-            if (int.TryParse(answer, out int instanceChoice) && instanceChoice > 0 && instanceChoice <= instances.Count)
+            if (int.TryParse(answer, out int instanceChoice) && instanceChoice >= 0 && instanceChoice <= instances.Count)
             {
-                instanceUsed = instances[instanceChoice - 1];
+                if (instanceChoice == 0)
+                {
+                    Console.WriteLine("Input path to MSBuild deployment:");
+                    var msbuildPath = Console.ReadLine();
+
+                    if (!Directory.Exists(msbuildPath))
+                    {
+                        Console.WriteLine($"Directory does not exist: {msbuildPath}");
+                        Environment.Exit(-1);
+                    }
+
+                    return (null, msbuildPath);
+
+                }
+                else
+                {
+                    var instanceUsed = instances[instanceChoice - 1];
+                    return (instanceUsed, null);
+                }
             }
             else
             {
@@ -77,7 +104,7 @@ namespace BuilderApp
                 Environment.Exit(-1);
             }
 
-            return instanceUsed;
+            throw new Exception("Invalid parsing");
         }
 
         private static void Header()

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -69,15 +69,21 @@ namespace Microsoft.Build.Locator
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
 
-            RegisterMSbuildPath(instance.MSBuildPath);
+            RegisterMSBuildPath(instance.MSBuildPath);
         }
 
         /// <summary>
         ///     Add assembly resolution for Microsoft.Build core dlls in the current AppDomain from the specified
         ///     path.
         /// </summary>
-        /// <param name="msbuildPath"></param>
-        public static void RegisterMSbuildPath(string msbuildPath)
+        /// <param name="msbuildPath">
+        ///     Path to the directory containing a deployment of MSBuild binaries.
+        ///     A minimal MSBuild deployment would be the publish result of the Microsoft.Build.Runtime package.
+        ///
+        ///     In order to restore and build real projects, one needs a deployment that contains the rest of the toolchain (nuget, compilers, etc.).
+        ///     Such deployments can be found in installations such as Visual Studio or dotnet CLI.
+        /// </param>
+        public static void RegisterMSBuildPath(string msbuildPath)
         {
             var loadedMSBuildAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(IsMSBuildAssembly);
             if (loadedMSBuildAssemblies.Any())

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -69,6 +69,16 @@ namespace Microsoft.Build.Locator
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
 
+            RegisterMSbuildPath(instance.MSBuildPath);
+        }
+
+        /// <summary>
+        ///     Add assembly resolution for Microsoft.Build core dlls in the current AppDomain from the specified
+        ///     path.
+        /// </summary>
+        /// <param name="msbuildPath"></param>
+        public static void RegisterMSbuildPath(string msbuildPath)
+        {
             var loadedMSBuildAssemblies = AppDomain.CurrentDomain.GetAssemblies().Where(IsMSBuildAssembly);
             if (loadedMSBuildAssemblies.Any())
             {
@@ -89,7 +99,7 @@ namespace Microsoft.Build.Locator
                 var assemblyName = new AssemblyName(eventArgs.Name);
                 if (IsMSBuildAssembly(assemblyName))
                 {
-                    var targetAssembly = Path.Combine(instance.MSBuildPath, assemblyName.Name + ".dll");
+                    var targetAssembly = Path.Combine(msbuildPath, assemblyName.Name + ".dll");
                     return File.Exists(targetAssembly) ? Assembly.LoadFrom(targetAssembly) : null;
                 }
 


### PR DESCRIPTION
Useful if you know exactly where MSBuild is, for example if you want to point it to the msbuild repo bootstrap directory.