### PR TITLE
Set copyright to Microsoft-required phrasing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Authors>Microsoft</Authors>
-    <Copyright>Copyright © Microsoft Corporation</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=825694</PackageIconUrl>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/Microsoft/MSBuildLocator</PackageProjectUrl>


### PR DESCRIPTION
Pushes to nuget.org were failing due to the mismatched string.