### PR TITLE
Fix for MsBuild versions less then 15

### DIFF
--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.props
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.props
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="EnsureMSBuildAssembliesNotCopied" AfterTargets="Build" Condition="'$(DisableMSBuildAssemblyCopyCheck)' != 'true'">
     <ItemGroup>
       <MSBuildPackagesWithoutPrivateAssets


### PR DESCRIPTION
Allow to build projects referencing MSBuildLocator with MSBuild
versions older then 15

Change-Id: I5df8a2843e018d74de0c8e308d7f765ccb70fef9