### PR TITLE
Fix NullReferenceException in GetDevConsoleInstance()

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -345,7 +345,10 @@ namespace Microsoft.Build.Locator
                     Version.TryParse(versionString, out version);
                 }
 
-                return new VisualStudioInstance("DEVCONSOLE", path, version, DiscoveryType.DeveloperConsole);
+                if(version != null)
+                {
+                    return new VisualStudioInstance("DEVCONSOLE", path, version, DiscoveryType.DeveloperConsole);
+                }
             }
 
             return null;


### PR DESCRIPTION
Fixes #65 

When the environment variable `VSINSTALLDIR` was set but `VisualStudioVersion` was not, `GetDevConsoleInstance()` was throwing a `NullReferenceException ` because a null-Version was passed to the `VisualStudioInstance` constructor.

This PR adds a check to ensure version is not null. If the version is null, `GetDevConsoleInstance` will return null (i.e. no VS instance found)
