### PR TITLE
Add support for finding CoreXT instances

### DIFF
--- a/src/MSBuildLocator.Tests/CoreXTTests.cs
+++ b/src/MSBuildLocator.Tests/CoreXTTests.cs
@@ -18,14 +18,13 @@ namespace Microsoft.Build.Locator.Tests
         public void DiscoverCoreXT()
         {
             const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
-            const string expectedVisualStudioPath = @"C:\16.0";
-            var expectedVisualStudioVersion = new Version(16, 1, 1);
+            var expectedVisualStudioVersion = new Version(16, 0);
 
             var visualStudioInstances = new List<VisualStudioInstance>
             {
                 new VisualStudioInstance("14.0", @"C:\14.0", new Version(14, 0), DiscoveryType.VisualStudioSetup),
                 new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
-                new VisualStudioInstance("16.0", expectedVisualStudioPath, expectedVisualStudioVersion, DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("16.0", expectedMSBuildPath, expectedVisualStudioVersion, DiscoveryType.VisualStudioSetup),
             };
 
             using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
@@ -39,81 +38,9 @@ namespace Microsoft.Build.Locator.Tests
 
                 instance.ShouldNotBeNull();
 
-                instance.VisualStudioRootPath.ShouldBe(expectedVisualStudioPath);
+                instance.VisualStudioRootPath.ShouldBe(expectedMSBuildPath);
                 instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
                 instance.Version.ShouldBe(expectedVisualStudioVersion);
-                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
-                instance.Name.ShouldBe("COREXT");
-            }
-        }
-
-        /// <summary>
-        /// When more than one version of Visual Studio is installed, the newest one that matches the major version is returned.
-        /// </summary>
-        [Fact]
-        public void LatestVisualStudioReturned()
-        {
-            const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
-            const string expectedVisualStudioPath = @"C:\16.2";
-            var expectedVisualStudioVersion = new Version(16, 2);
-
-            var visualStudioInstances = new List<VisualStudioInstance>
-            {
-                new VisualStudioInstance("14.0", @"C:\14.0", new Version(14, 0), DiscoveryType.VisualStudioSetup),
-                new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
-                new VisualStudioInstance("16.0", @"C:\16.0", new Version(16, 0), DiscoveryType.VisualStudioSetup),
-                new VisualStudioInstance("16.1", @"C:\16.1", new Version(16, 1), DiscoveryType.VisualStudioSetup),
-                new VisualStudioInstance("16.2", expectedVisualStudioPath, expectedVisualStudioVersion, DiscoveryType.VisualStudioSetup),
-            };
-
-            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
-            {
-                ["MsBuildToolset"] = "160",
-                ["MSBuildToolsPath_160"] = expectedMSBuildPath,
-                ["VisualStudioVersion"] = "16.0"
-            }))
-            {
-                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => true);
-
-                instance.ShouldNotBeNull();
-
-                instance.VisualStudioRootPath.ShouldBe(expectedVisualStudioPath);
-                instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
-                instance.Version.ShouldBe(expectedVisualStudioVersion);
-                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
-                instance.Name.ShouldBe("COREXT");
-            }
-        }
-
-        /// <summary>
-        /// When there's no matching Visual Studio installation for the configured build environment, the MSBuild path is still set.
-        /// </summary>
-        [Fact]
-        public void NoVisualStudioInstance()
-        {
-            const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
-            const string expectedVisualStudioVersion = "16.0";
-
-            var visualStudioInstances = new List<VisualStudioInstance>
-            {
-                // Only Visual Studio 2017 installed
-                new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
-            };
-
-            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
-            {
-                ["MsBuildToolset"] = "160",
-                ["MSBuildToolsPath_160"] = expectedMSBuildPath,
-                ["VisualStudioVersion"] = "16.0"
-            }))
-            {
-                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => true);
-
-                instance.ShouldNotBeNull();
-
-                instance.VisualStudioRootPath.ShouldBeNull();
-                instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
-                instance.Version.ShouldBe(Version.Parse(expectedVisualStudioVersion));
                 instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
                 instance.Name.ShouldBe("COREXT");
             }
@@ -142,7 +69,7 @@ namespace Microsoft.Build.Locator.Tests
 
                 instance.ShouldNotBeNull();
 
-                instance.VisualStudioRootPath.ShouldBeNull();
+                instance.VisualStudioRootPath.ShouldBe(expectedMSBuildToolsPath);
                 instance.MSBuildPath.ShouldBe(expectedMSBuildToolsPath);
                 instance.Version.ShouldBe(Version.Parse(visualStudioVersion));
                 instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
@@ -180,5 +107,6 @@ namespace Microsoft.Build.Locator.Tests
             }
         }
     }
+
 #endif
 }

--- a/src/MSBuildLocator.Tests/CoreXTTests.cs
+++ b/src/MSBuildLocator.Tests/CoreXTTests.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Build.Locator.Tests
+{
+#if NET46
+    public class CoreXTTests
+    {
+        /// <summary>
+        /// When there are multiple major versions of Visual Studio installed, the correct one is returned.
+        /// </summary>
+        [Fact]
+        public void DiscoverCoreXT()
+        {
+            const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
+            const string expectedVisualStudioPath = @"C:\16.0";
+            var expectedVisualStudioVersion = new Version(16, 1, 1);
+
+            var visualStudioInstances = new List<VisualStudioInstance>
+            {
+                new VisualStudioInstance("14.0", @"C:\14.0", new Version(14, 0), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("16.0", expectedVisualStudioPath, expectedVisualStudioVersion, DiscoveryType.VisualStudioSetup),
+            };
+
+            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
+            {
+                ["MsBuildToolset"] = "160",
+                ["MSBuildToolsPath_160"] = expectedMSBuildPath,
+                ["VisualStudioVersion"] = "16.0"
+            }))
+            {
+                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => true);
+
+                instance.ShouldNotBeNull();
+
+                instance.VisualStudioRootPath.ShouldBe(expectedVisualStudioPath);
+                instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
+                instance.Version.ShouldBe(expectedVisualStudioVersion);
+                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
+                instance.Name.ShouldBe("COREXT");
+            }
+        }
+
+        /// <summary>
+        /// When more than one version of Visual Studio is installed, the newest one that matches the major version is returned.
+        /// </summary>
+        [Fact]
+        public void LatestVisualStudioReturned()
+        {
+            const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
+            const string expectedVisualStudioPath = @"C:\16.2";
+            var expectedVisualStudioVersion = new Version(16, 2);
+
+            var visualStudioInstances = new List<VisualStudioInstance>
+            {
+                new VisualStudioInstance("14.0", @"C:\14.0", new Version(14, 0), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("16.0", @"C:\16.0", new Version(16, 0), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("16.1", @"C:\16.1", new Version(16, 1), DiscoveryType.VisualStudioSetup),
+                new VisualStudioInstance("16.2", expectedVisualStudioPath, expectedVisualStudioVersion, DiscoveryType.VisualStudioSetup),
+            };
+
+            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
+            {
+                ["MsBuildToolset"] = "160",
+                ["MSBuildToolsPath_160"] = expectedMSBuildPath,
+                ["VisualStudioVersion"] = "16.0"
+            }))
+            {
+                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => true);
+
+                instance.ShouldNotBeNull();
+
+                instance.VisualStudioRootPath.ShouldBe(expectedVisualStudioPath);
+                instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
+                instance.Version.ShouldBe(expectedVisualStudioVersion);
+                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
+                instance.Name.ShouldBe("COREXT");
+            }
+        }
+
+        /// <summary>
+        /// When there's no matching Visual Studio installation for the configured build environment, the MSBuild path is still set.
+        /// </summary>
+        [Fact]
+        public void NoVisualStudioInstance()
+        {
+            const string expectedMSBuildPath = @"C:\Cx\.A\MsBuild.Corext";
+            const string expectedVisualStudioVersion = "16.0";
+
+            var visualStudioInstances = new List<VisualStudioInstance>
+            {
+                // Only Visual Studio 2017 installed
+                new VisualStudioInstance("15.9", @"C:\15.9", new Version(15, 9), DiscoveryType.VisualStudioSetup),
+            };
+
+            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
+            {
+                ["MsBuildToolset"] = "160",
+                ["MSBuildToolsPath_160"] = expectedMSBuildPath,
+                ["VisualStudioVersion"] = "16.0"
+            }))
+            {
+                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => true);
+
+                instance.ShouldNotBeNull();
+
+                instance.VisualStudioRootPath.ShouldBeNull();
+                instance.MSBuildPath.ShouldBe(expectedMSBuildPath);
+                instance.Version.ShouldBe(Version.Parse(expectedVisualStudioVersion));
+                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
+                instance.Name.ShouldBe("COREXT");
+            }
+        }
+
+        /// <summary>
+        /// Iterates known versions that should return something (15.0+)
+        /// </summary>
+        /// <param name="msbuildToolset"></param>
+        /// <param name="visualStudioVersion"></param>
+        [Theory]
+        [InlineData("150", "15.0")]
+        [InlineData("160", "16.0")]
+        public void ReturnsInstanceWhenEnvironmentFound(string msbuildToolset, string visualStudioVersion)
+        {
+            const string expectedMSBuildToolsPath = @"D:\Cx\.A\MSBuild.Corext";
+
+            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
+            {
+                ["MsBuildToolset"] = msbuildToolset,
+                [$"MSBuildToolsPath_{msbuildToolset}"] = expectedMSBuildToolsPath,
+                ["VisualStudioVersion"] = visualStudioVersion,
+            }))
+            {
+                var instance = MSBuildLocator.GetCoreXTInstance(new List<VisualStudioInstance>(), directoryExists: (path) => true);
+
+                instance.ShouldNotBeNull();
+
+                instance.VisualStudioRootPath.ShouldBeNull();
+                instance.MSBuildPath.ShouldBe(expectedMSBuildToolsPath);
+                instance.Version.ShouldBe(Version.Parse(visualStudioVersion));
+                instance.DiscoveryType.ShouldBe(DiscoveryType.CoreXT);
+                instance.Name.ShouldBe("COREXT");
+            }
+        }
+
+        /// <summary>
+        /// Iterates all conditions under which an instance should not be returned.
+        /// </summary>
+        [Theory]
+        [InlineData(null, "NotNull", "NotNull", true)]
+        [InlineData("NotAnInteger", "NotNull", "NotNull", true)]
+        [InlineData("149", "NotNull", "NotNull", true)]
+        [InlineData("160", null, "NotNull", true)]
+        [InlineData("160", @"D:\Cx\.A\MSBuild.Corext", null, true)]
+        [InlineData("160", @"D:\Cx\.A\MSBuild.Corext", "16.0", false)]
+        public void ReturnsNullWhenEnvironmentNotFound(string msbuildToolset, string msbuildToolsPath, string visualStudioVersion, bool directoryExists)
+        {
+            var visualStudioInstances = new List<VisualStudioInstance>
+            {
+                new VisualStudioInstance("16.0", @"C:\16.0", new Version(16, 0), DiscoveryType.VisualStudioSetup),
+            };
+
+            using (new TemporaryEnvironmentVariables(new Dictionary<string, string>
+            {
+                ["MsBuildToolset"] = msbuildToolset,
+                ["MSBuildToolsPath_160"] = msbuildToolsPath,
+                ["VisualStudioVersion"] = visualStudioVersion,
+            }))
+            {
+                var instance = MSBuildLocator.GetCoreXTInstance(visualStudioInstances, directoryExists: (path) => directoryExists);
+
+                instance.ShouldBeNull();
+            }
+        }
+    }
+#endif
+}

--- a/src/MSBuildLocator.Tests/QueryOptionsTests.cs
+++ b/src/MSBuildLocator.Tests/QueryOptionsTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Build.Locator.Tests
                 new VisualStudioInstance("A7D13212839F4997AF65F7F74618EBAB", "none", new Version(1, 0), DiscoveryType.DeveloperConsole),
                 new VisualStudioInstance("DBF404629ED2408182263033F0358A1E", "none", new Version(1, 0), DiscoveryType.VisualStudioSetup),
                 new VisualStudioInstance("98B38291074547D89A86758A26621EF3", "none", new Version(1, 0), DiscoveryType.DotNetSdk),
+                new VisualStudioInstance("055AC20F60594F85BFC7CC63A5CFDA81", "none", new Version(1, 0), DiscoveryType.CoreXT),
             };
 
             VerifyQueryResults(instances, DiscoveryType.DeveloperConsole, "A7D13212839F4997AF65F7F74618EBAB");
@@ -27,6 +28,8 @@ namespace Microsoft.Build.Locator.Tests
             VerifyQueryResults(instances, DiscoveryType.DeveloperConsole | DiscoveryType.DotNetSdk, "A7D13212839F4997AF65F7F74618EBAB", "98B38291074547D89A86758A26621EF3");
             VerifyQueryResults(instances, DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup | DiscoveryType.DotNetSdk, "A7D13212839F4997AF65F7F74618EBAB", "DBF404629ED2408182263033F0358A1E", "98B38291074547D89A86758A26621EF3");
             VerifyQueryResults(instances, DiscoveryType.VisualStudioSetup | DiscoveryType.DotNetSdk, "DBF404629ED2408182263033F0358A1E", "98B38291074547D89A86758A26621EF3");
+            VerifyQueryResults(instances, DiscoveryType.CoreXT, "055AC20F60594F85BFC7CC63A5CFDA81");
+            VerifyQueryResults(instances, DiscoveryType.CoreXT | DiscoveryType.DotNetSdk, "055AC20F60594F85BFC7CC63A5CFDA81", "98B38291074547D89A86758A26621EF3");
         }
 
         [Fact]

--- a/src/MSBuildLocator.Tests/TemporaryEnvironmentVariables.cs
+++ b/src/MSBuildLocator.Tests/TemporaryEnvironmentVariables.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Locator.Tests
+{
+    /// <summary>
+    /// Represents a class for temporarily setting environment variables.
+    /// </summary>
+    public class TemporaryEnvironmentVariables : IDisposable
+    {
+        private readonly Dictionary<string, string> _backup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TemporaryEnvironmentVariables" /> class.
+        /// </summary>
+        /// <param name="environmentVariables">A <see cref="IDictionary{String,String}" /> containing the temporary environment variables to set.</param>
+        public TemporaryEnvironmentVariables(IDictionary<string, string> environmentVariables)
+        {
+            if (environmentVariables == null)
+            {
+                throw new ArgumentNullException(nameof(environmentVariables));
+            }
+
+            foreach (var environmentVariable in environmentVariables)
+            {
+                // Back up existing value
+                _backup[environmentVariable.Key] = Environment.GetEnvironmentVariable(environmentVariable.Key);
+
+                // Set new value
+                Environment.SetEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var environmentVariable in _backup)
+            {
+                // Restore backed up value
+                Environment.SetEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
+            }
+        }
+    }
+}

--- a/src/MSBuildLocator/DiscoveryType.cs
+++ b/src/MSBuildLocator/DiscoveryType.cs
@@ -25,6 +25,11 @@ namespace Microsoft.Build.Locator
         /// <summary>
         ///     Discovery via dotnet --info.
         /// </summary>
-        DotNetSdk = 4
+        DotNetSdk = 4,
+
+        /// <summary>
+        /// Discovery via the Microsoft internal-only build environment CoreXT.
+        /// </summary>
+        CoreXT = 8
     }
 }

--- a/src/MSBuildLocator/DiscoveryType.cs
+++ b/src/MSBuildLocator/DiscoveryType.cs
@@ -30,6 +30,6 @@ namespace Microsoft.Build.Locator
         /// <summary>
         /// Discovery via the Microsoft internal-only build environment CoreXT.
         /// </summary>
-        CoreXT = 8
+        CoreXT = 8,
     }
 }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -349,7 +349,6 @@ namespace Microsoft.Build.Locator
 
             var msbuildPath = Environment.GetEnvironmentVariable($"MSBuildToolsPath_{toolset}");
 
-
             if (string.IsNullOrWhiteSpace(msbuildPath) || !(directoryExists ?? Directory.Exists)(msbuildPath))
             {
                 // A corresponding MSBuildToolsPath_XXX env var must be set and it must exist
@@ -361,7 +360,6 @@ namespace Microsoft.Build.Locator
                 // VisualStudioVersion env var must be set to a valid version
                 return null;
             }
-
 
             // Find the newest installed Visual Studio instance that corresponds with the VisualStudioVersion set by CoreXT
             VisualStudioInstance visualStudioInstance = (visualStudioInstances ?? VisualStudioLocationHelper.GetInstances()).Where(i => i.Version.Major == visualStudioVersion.Major).OrderByDescending(i => i.Version).FirstOrDefault();

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -361,11 +361,8 @@ namespace Microsoft.Build.Locator
                 return null;
             }
 
-            // Find the newest installed Visual Studio instance that corresponds with the VisualStudioVersion set by CoreXT
-            VisualStudioInstance visualStudioInstance = (visualStudioInstances ?? VisualStudioLocationHelper.GetInstances()).Where(i => i.Version.Major == visualStudioVersion.Major).OrderByDescending(i => i.Version).FirstOrDefault();
-
             // Return a composite with the Visual Studio path and the path of the CoreXT MSBuild
-            return new VisualStudioInstance("COREXT", visualStudioInstance?.VisualStudioRootPath, visualStudioInstance?.Version ?? visualStudioVersion, DiscoveryType.CoreXT, msbuildPath);
+            return new VisualStudioInstance("COREXT", msbuildPath, visualStudioVersion, DiscoveryType.CoreXT);
         }
 
         private static VisualStudioInstance GetDevConsoleInstance()

--- a/src/MSBuildLocator/VisualStudioInstance.cs
+++ b/src/MSBuildLocator/VisualStudioInstance.cs
@@ -11,13 +11,12 @@ namespace Microsoft.Build.Locator
     /// </summary>
     public class VisualStudioInstance
     {
-        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType, string msbuildPath = null)
+        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType)
         {
             Name = name;
             VisualStudioRootPath = path;
             Version = version;
             DiscoveryType = discoveryType;
-            MSBuildPath = msbuildPath;
 
             switch (discoveryType)
             {
@@ -29,9 +28,8 @@ namespace Microsoft.Build.Locator
                         Path.Combine(VisualStudioRootPath, "MSBuild", "15.0", "Bin");
                     break;
                 case DiscoveryType.DotNetSdk:
-                    MSBuildPath = VisualStudioRootPath;
-                    break;
                 case DiscoveryType.CoreXT:
+                    MSBuildPath = VisualStudioRootPath;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(discoveryType), discoveryType, null);

--- a/src/MSBuildLocator/VisualStudioInstance.cs
+++ b/src/MSBuildLocator/VisualStudioInstance.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Build.Locator
     /// </summary>
     public class VisualStudioInstance
     {
-        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType)
+        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType, string msbuildPath = null)
         {
             Name = name;
             VisualStudioRootPath = path;
             Version = version;
             DiscoveryType = discoveryType;
+            MSBuildPath = msbuildPath;
 
             switch (discoveryType)
             {
@@ -29,6 +30,8 @@ namespace Microsoft.Build.Locator
                     break;
                 case DiscoveryType.DotNetSdk:
                     MSBuildPath = VisualStudioRootPath;
+                    break;
+                case DiscoveryType.CoreXT:
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(discoveryType), discoveryType, null);


### PR DESCRIPTION
CoreXT is a Microsoft internal-only build environment.  We need tools to work in all environments so adding support for CoreXT makes MSBuildLocator more useful.