### PR TITLE
Included additional assemblies to load on demand

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -22,9 +22,12 @@ namespace Microsoft.Build.Locator
         private static readonly string[] s_msBuildAssemblies =
         {
             "Microsoft.Build",
+            "Microsoft.Build.Engine",
             "Microsoft.Build.Framework",
             "Microsoft.Build.Tasks.Core",
-            "Microsoft.Build.Utilities.Core"
+            "Microsoft.Build.Utilities.Core",
+            "System.Runtime.CompilerServices.Unsafe",
+            "System.Numerics.Vectors"
         };
 
 #if NET46


### PR DESCRIPTION
Added Microsoft.Build.Engine and two supporting assemblies to the set that can be loaded.  These needed to be included in order for my project to work properly with the build locator.
