### PR TITLE
Add binding redirects for the sample

### DIFF
--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -24,4 +24,8 @@
     <ProjectReference Include="..\..\src\MSBuildLocator\Microsoft.Build.Locator.csproj" />
   </ItemGroup>
 
+  <!-- Explicitly import the file that gives auto binding redirects for package users.
+       Not necessary if you use the package! -->
+  <Import Project="..\..\src\MSBuildLocator\build\Microsoft.Build.Locator.props"/>
+
 </Project>


### PR DESCRIPTION
Consumers of the package get automatic binding redirects for MSBuild
assemblies, but the sample wasn't getting that behavior. Import the
build logic as though from the package.

This was breaking a .NET 5.0 project on my machine.