### PR TITLE
FEATURE_VISUALSTUDIOSETUP for .NET Core too

### DIFF
--- a/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
+++ b/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MSBuildLocator\key.snk</AssemblyOriginatorKeyFile>

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
     <DebugType>full</DebugType>
 
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
@@ -16,13 +16,13 @@
     <Description>Package that assists in locating and using an installed version of MSBuild 15.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.21" PrivateAssets="all" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2262-g94fae01e" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.Build.Locator
         /// </summary>
         public static VisualStudioInstanceQueryOptions Default => new VisualStudioInstanceQueryOptions
         {
-            DiscoveryTypes =
+            DiscoveryTypes = 0
 #if FEATURE_VISUALSTUDIOSETUP
-                DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
+                | DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
 #endif
 #if NETCOREAPP
-                DiscoveryType.DotNetSdk
+                | DiscoveryType.DotNetSdk
 #endif
         };
 


### PR DESCRIPTION
- It relies on a pre-release version of  `Microsoft.VisualStudio.Setup.Configuration.Interop` so not really ready to be merged
- I had to bump to `netcoreapp3.1` so that it compiles correcly
- Not tested => I just wanted to open the discussion on the subject