### PR TITLE
Load all assemblies from the MSBuild folder if not already loaded

### DIFF
--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -206,21 +206,6 @@ namespace Microsoft.Build.Locator
                     string targetAssembly = Path.Combine(msbuildPath, assemblyName.Name + ".dll");
                     if (File.Exists(targetAssembly))
                     {
-                        // If the assembly was already loaded, return that. This could theoretically cause version problems, but the user shouldn't be
-                        // trying to load an MSBuild that is incompatible with the version of the assembly they currently have loaded.
-                        Assembly loadedAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name.Equals(assemblyName.Name));
-                        if (loadedAssembly != null)
-                        {
-                            loadedAssemblies.Add(assemblyName.FullName, loadedAssembly);
-                            return loadedAssembly;
-                        }
-
-                        // Automatically unregister the handler once all supported assemblies have been loaded.
-                        if (Interlocked.Increment(ref numResolvedAssemblies) == s_msBuildAssemblies.Length)
-                        {
-                            Unregister();
-                        }
-
                         assembly = Assembly.LoadFrom(targetAssembly);
                         loadedAssemblies.Add(assemblyName.FullName, assembly);
                         return assembly;

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Locator
 #endif
 
         // Used to determine when it's time to unregister the registeredHandler.
-        private static int numResolvedAssemblies;
+        private static bool registerCalled = false;
 
         /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild is currently registered.
@@ -142,6 +142,7 @@ namespace Microsoft.Build.Locator
         /// </param>
         public static void RegisterMSBuildPath(string msbuildPath)
         {
+            registerCalled = true;
             if (string.IsNullOrWhiteSpace(msbuildPath))
             {
                 throw new ArgumentException("Value may not be null or whitespace", nameof(msbuildPath));
@@ -227,7 +228,7 @@ namespace Microsoft.Build.Locator
             if (!IsRegistered)
             {
                 var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine;
-                if (numResolvedAssemblies == 0)
+                if (!registerCalled)
                 {
                     error += $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method.";
                 }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -34,8 +34,8 @@ namespace Microsoft.Build.Locator
         private static Func<AssemblyLoadContext, AssemblyName, Assembly> s_registeredHandler;
 #endif
 
-        // Used to determine when it's time to unregister the registeredHandler.
-        private static bool registerCalled = false;
+        // AssemblyResolve event can fire multiple times for the same assembly, so keep track of what's already been loaded.
+        private static Dictionary<string, Assembly> loadedAssemblies = new Dictionary<string, Assembly>();
 
         /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild is currently registered.
@@ -48,9 +48,7 @@ namespace Microsoft.Build.Locator
         /// <remarks>
         ///     If any Microsoft.Build assemblies are already loaded into the current AppDomain, the value will be false.
         /// </remarks>
-        public static bool CanRegister => !IsRegistered && !LoadedMsBuildAssemblies.Any();
-
-        private static IEnumerable<Assembly> LoadedMsBuildAssemblies => AppDomain.CurrentDomain.GetAssemblies().Where(IsMSBuildAssembly);
+        public static bool CanRegister => !IsRegistered && !loadedAssemblies.Any();
 
         /// <summary>
         ///     Query for all Visual Studio instances.
@@ -142,7 +140,6 @@ namespace Microsoft.Build.Locator
         /// </param>
         public static void RegisterMSBuildPath(string msbuildPath)
         {
-            registerCalled = true;
             if (string.IsNullOrWhiteSpace(msbuildPath))
             {
                 throw new ArgumentException("Value may not be null or whitespace", nameof(msbuildPath));
@@ -155,8 +152,6 @@ namespace Microsoft.Build.Locator
 
             if (!CanRegister)
             {
-                var loadedAssemblyList = string.Join(Environment.NewLine, LoadedMsBuildAssemblies.Select(a => a.GetName()));
-
                 var error = $"{typeof(MSBuildLocator)}.{nameof(RegisterInstance)} was called, but MSBuild assemblies were already loaded." +
                     Environment.NewLine +
                     $"Ensure that {nameof(RegisterInstance)} is called before any method that directly references types in the Microsoft.Build namespace has been called." +
@@ -166,13 +161,10 @@ namespace Microsoft.Build.Locator
                     "For more details, see aka.ms/RegisterMSBuildLocator" +
                     Environment.NewLine +
                     "Loaded MSBuild assemblies: " +
-                    loadedAssemblyList;
+                    string.Join(Environment.NewLine, loadedAssemblies.Keys);
 
                 throw new InvalidOperationException(error);
             }
-
-            // AssemblyResolve event can fire multiple times for the same assembly, so keep track of what's already been loaded.
-            var loadedAssemblies = new Dictionary<string, Assembly>();
 
             // Saving the handler in a static field so it can be unregistered later.
 #if NET46
@@ -204,6 +196,8 @@ namespace Microsoft.Build.Locator
                         return assembly;
                     }
 
+                    // Look in the MSBuild folder for any unresolved reference. It may be a dependency
+                    // of MSBuild or a task.
                     string targetAssembly = Path.Combine(msbuildPath, assemblyName.Name + ".dll");
                     if (File.Exists(targetAssembly))
                     {
@@ -227,18 +221,9 @@ namespace Microsoft.Build.Locator
         {
             if (!IsRegistered)
             {
-                var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine;
-                if (!registerCalled)
-                {
-                    error += $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method.";
-                }
-                else
-                {
-                    error += "Unregistration automatically occurs once all supported assemblies are loaded into the current AppDomain and so generally is not necessary to call directly.";
-                }
-
-                error += Environment.NewLine +
-                         $"{nameof(IsRegistered)} should be used to determine whether calling {nameof(Unregister)} is a valid operation.";
+                var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine +
+                            $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method." + Environment.NewLine +
+                            $"{nameof(IsRegistered)} should be used to determine whether calling {nameof(Unregister)} is a valid operation.";
 
                 throw new InvalidOperationException(error);
             }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -34,9 +34,6 @@ namespace Microsoft.Build.Locator
         private static Func<AssemblyLoadContext, AssemblyName, Assembly> s_registeredHandler;
 #endif
 
-        // Used to determine when it's time to unregister the registeredHandler.
-        private static bool registerCalled = false;
-
         /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild is currently registered.
         /// </summary>
@@ -142,7 +139,6 @@ namespace Microsoft.Build.Locator
         /// </param>
         public static void RegisterMSBuildPath(string msbuildPath)
         {
-            registerCalled = true;
             if (string.IsNullOrWhiteSpace(msbuildPath))
             {
                 throw new ArgumentException("Value may not be null or whitespace", nameof(msbuildPath));
@@ -229,19 +225,9 @@ namespace Microsoft.Build.Locator
         {
             if (!IsRegistered)
             {
-                var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine;
-                if (!registerCalled)
-                {
-                    error += $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method.";
-                }
-                else
-                {
-                    error += "Unregistration automatically occurs once all supported assemblies are loaded into the current AppDomain and so generally is not necessary to call directly.";
-                }
-
-                error += Environment.NewLine +
-                         $"{nameof(IsRegistered)} should be used to determine whether calling {nameof(Unregister)} is a valid operation.";
-
+                var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine +
+                            $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method." + Environment.NewLine +
+                            $"{nameof(IsRegistered)} should be used to determine whether calling {nameof(Unregister)} is a valid operation.";
                 throw new InvalidOperationException(error);
             }
 


### PR DESCRIPTION
Changes the check for previously loaded assemblies to only fail if we already registered them via MSBuildLocator. Then adds previously loaded assemblies to the list of loaded assemblies so they aren't loaded again.

This may cause version mismatch issues, but if you had previously loaded some but not all of our assemblies, I'd say that's something for you to figure out. 😄 

Fixes #103.

Also Fixes #38.