### PR TITLE
Indicates whether Roslyn is included

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Build.Locator
                 name: ".NET Core SDK",
                 path: dotNetSdkPath,
                 version: new Version(major, minor, patch),
-                discoveryType: DiscoveryType.DotNetSdk);
+                discoveryType: DiscoveryType.DotNetSdk,
+                true);
         }
 
         private static string GetDotNetBasePath(string workingDirectory)

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Build.Locator
 
                 if(version != null)
                 {
-                    return new VisualStudioInstance("DEVCONSOLE", path, version, DiscoveryType.DeveloperConsole);
+                    return new VisualStudioInstance("DEVCONSOLE", path, version, DiscoveryType.DeveloperConsole, false);
                 }
             }
 

--- a/src/MSBuildLocator/VisualStudioInstance.cs
+++ b/src/MSBuildLocator/VisualStudioInstance.cs
@@ -11,12 +11,13 @@ namespace Microsoft.Build.Locator
     /// </summary>
     public class VisualStudioInstance
     {
-        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType)
+        internal VisualStudioInstance(string name, string path, Version version, DiscoveryType discoveryType, bool hasCSharp)
         {
             Name = name;
             VisualStudioRootPath = path;
             Version = version;
             DiscoveryType = discoveryType;
+            ContainsRoslynCompiler = hasCSharp;
 
             switch (discoveryType)
             {
@@ -59,5 +60,10 @@ namespace Microsoft.Build.Locator
         ///     Indicates how this instance was discovered.
         /// </summary>
         public DiscoveryType DiscoveryType { get; }
+
+        /// <summary>
+        /// Indicates whether this instance has the C# package installed.
+        /// </summary>
+        public bool ContainsRoslynCompiler { get; }
     }
 }

--- a/src/MSBuildLocator/VisualStudioLocationHelper.cs
+++ b/src/MSBuildLocator/VisualStudioLocationHelper.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Setup.Configuration;
 
@@ -53,24 +54,17 @@ namespace Microsoft.Build.Locator
                     if (state == InstanceState.Complete ||
                         (state.HasFlag(InstanceState.Registered) && state.HasFlag(InstanceState.NoRebootRequired)))
                     {
-                        bool instanceHasMSBuild = false;
-
-                        foreach (ISetupPackageReference package in instance.GetPackages())
-                        {
-                            if (string.Equals(package.GetId(), "Microsoft.Component.MSBuild", StringComparison.OrdinalIgnoreCase))
-                            {
-                                instanceHasMSBuild = true;
-                                break;
-                            }
-                        }
+                        bool instanceHasMSBuild = instance.GetPackages().Any(package => package.GetId().Equals("Microsoft.Component.MSBuild", StringComparison.OrdinalIgnoreCase));
 
                         if (instanceHasMSBuild)
                         {
+                            bool instanceHasCSCompiler = instance.GetPackages().Any(package => package.GetId().Equals("Microsoft.VisualStudio.Component.Roslyn.Compiler", StringComparison.OrdinalIgnoreCase));
                             validInstances.Add(new VisualStudioInstance(
                                 instance.GetDisplayName(),
                                 instance.GetInstallationPath(),
                                 version,
-                                DiscoveryType.VisualStudioSetup));
+                                DiscoveryType.VisualStudioSetup,
+                                instanceHasCSCompiler));
                         }
                     }
                 } while (fetched > 0);


### PR DESCRIPTION
Fixes #22

I didn't see an obvious way to determine whether the C# compiler was installed for the dotnet sdk, and I didn't want to replicate all the logic from VSLocationHelper for a command prompt. Maybe right?