### PR TITLE
Fix to return all installed DotNetSDK versions

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Build.Locator
             {
                 return null;
             }
-            
+
             // Components of the SDK often have dependencies on the runtime they shipped with, including that several tasks that shipped
             // in the .NET 5 SDK rely on the .NET 5.0 runtime. Assuming the runtime that shipped with a particular SDK has the same version,
             // this ensures that we don't choose an SDK that doesn't work with the runtime of the chosen application. This is not guaranteed
             // to always work but should work for now.
-            if (major > Environment.Version.Major ||
-                (major == Environment.Version.Major && minor > Environment.Version.Minor))
+            if (major < Environment.Version.Major ||
+                (major == Environment.Version.Major && minor < Environment.Version.Minor))
             {
                 return null;
             }
@@ -82,42 +82,40 @@ namespace Microsoft.Build.Locator
             const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
             
             Process process;
+            var lines = new List<string>();
             try
             {
-                var startInfo = new ProcessStartInfo("dotnet", "--info")
+                process = new Process()
                 {
-                    WorkingDirectory = workingDirectory,
-                    CreateNoWindow = true,
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true
+                    StartInfo = new ProcessStartInfo("dotnet", "--info")
+                    {
+                        WorkingDirectory = workingDirectory,
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    }
                 };
 
                 // Ensure that we set the DOTNET_CLI_UI_LANGUAGE environment variable to "en-US" before
                 // running 'dotnet --info'. Otherwise, we may get localized results.
-                startInfo.EnvironmentVariables[DOTNET_CLI_UI_LANGUAGE] = "en-US";
+                process.StartInfo.EnvironmentVariables[DOTNET_CLI_UI_LANGUAGE] = "en-US";
 
-                process = Process.Start(startInfo);
+                process.OutputDataReceived += (_, e) =>
+                {
+                    if (!string.IsNullOrWhiteSpace(e.Data))
+                    {
+                        lines.Add(e.Data);
+                    }
+                };
+
+                process.Start();
             }
             catch
             {
                 // when error running dotnet command, consider dotnet as not available
                 yield break;
             }
-
-            if (process.HasExited)
-            {
-                yield break;
-            }
-
-            var lines = new List<string>();
-            process.OutputDataReceived += (_, e) =>
-            {
-                if (!string.IsNullOrWhiteSpace(e.Data))
-                {
-                    lines.Add(e.Data);
-                }
-            };
 
             process.BeginOutputReadLine();
 
@@ -126,14 +124,16 @@ namespace Microsoft.Build.Locator
             var outputString = string.Join(Environment.NewLine, lines);
 
             var matched = DotNetBasePathRegex.Match(outputString);
-            if (!matched.Success)
+            // We return the version in use at the front of the list in order to ensure
+            // FirstOrDefault always returns the version in use.
+            // The BasePath might not be found if the required version (via global.json)
+            // is not installed. In that case, we can still iterate to the other SDKs installed
+            string basePath = null;
+            if (matched.Success)
             {
-                yield break; 
+                basePath = matched.Groups[1].Value.Trim();
+                yield return basePath; 
             }
-            
-            var basePath = matched.Groups[1].Value.Trim();
-
-            yield return basePath; // We return the version in use at the front of the list in order to ensure FirstOrDefault always returns the version in use.
 
             var lineSdkIndex = lines.FindIndex(line => line.Contains("SDKs installed"));
 


### PR DESCRIPTION
This PR is a proposed fix/improvements to the following PRs to address [qsharp-compiler#737](https://github.com/microsoft/qsharp-compiler/issues/737):
 - #79 Return all installed DotNetSDK versions
   - Fix console output event handling
     - Problem: if the "dotnet --info" process runs faster and completes before we subscribe to the output events we loose its output. And we also were checking if the process completes successfully before this [line](https://github.com/microsoft/MSBuildLocator/pull/79/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR98) we were existing without the actual list of SDKs.
     - Fixes:
       - [Subscribe to output events before starting the process](https://github.com/microsoft/MSBuildLocator/pull/117/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR104)
       - [Don't exit if the process has already finished](https://github.com/microsoft/MSBuildLocator/pull/117/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eL108)
   -  Fix to not require the base path to be present to return the full list of SDKs
      - Problem: the base path is not returned by "dotnet --info" if the required version (from global.json) is not found. Still, we could return the list of installed SDKs and let the caller method to decide whether or not to use the available SDKs.
       - Fix:  [if the base path is found return it, otherwise proceed to list the installed SDKs](https://github.com/microsoft/MSBuildLocator/pull/117/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR132)
 - #106 Only consider sdks from before the runtime 
   - Problem: I may be getting this wrong, but my understanding is that it would be ok for a older runtime to use a more recent SDK (assuming backward compatibility) and the opposite (newer SDK using an older runtime) might not be ok. So then, I think [this logic is backward](https://github.com/microsoft/MSBuildLocator/pull/106/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR57), because it's exiting when we have a greater version available to be used (major or minor). I'm not sure if this was a mistake or by-design and I'm not getting the problem it solved. But from the Quantum Development Kit perspective, the current logic is returning null when QDK (which is built against 3.1) runs on 5.0 and 3.1 is not available. The correct behavior (for QDK) is to allow 5.0 to be returned as the SDK to be used.
   - Fix: [allow greater versions, block lesser version](https://github.com/microsoft/MSBuildLocator/pull/117/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR57)

