### PR TITLE
Only look in extra NuGet directory from VS install

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Build.Locator
             }
 
             // Find and load NuGet assemblies if msbuildPath is in a VS installation
-            string nugetPath = Path.GetFullPath(Path.Combine(instance.MSBuildPath, "..", "..", "..", "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet"))
+            string nugetPath = Path.GetFullPath(Path.Combine(instance.MSBuildPath, "..", "..", "..", "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet"));
             if (Directory.Exists(nugetPath))
             {
                 RegisterMSBuildPath(new string[] { instance.MSBuildPath, nugetPath });

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -123,14 +123,11 @@ namespace Microsoft.Build.Locator
                 ApplyDotNetSdkEnvironmentVariables(instance.MSBuildPath);
             }
 
-            if (instance.DiscoveryType == DiscoveryType.VisualStudioSetup || instance.DiscoveryType == DiscoveryType.DeveloperConsole)
+            // Find and load NuGet assemblies if msbuildPath is in a VS installation
+            string nugetPath = Path.GetFullPath(Path.Combine(instance.MSBuildPath, "..", "..", "..", "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet"))
+            if (Directory.Exists(nugetPath))
             {
-                RegisterMSBuildPath(new string[]
-                {
-                    instance.MSBuildPath,
-                    // Find and load NuGet assemblies if msbuildPath is in a VS installation
-                    Path.GetFullPath(Path.Combine(instance.MSBuildPath, "..", "..", "..", "Common7", "IDE", "CommonExtensions", "Microsoft", "NuGet"))
-                });
+                RegisterMSBuildPath(new string[] { instance.MSBuildPath, nugetPath });
             }
             else
             {


### PR DESCRIPTION
I neglected to test the RegisterMSBuildPath to a not-VS location scenario, and it can fail. This should fix it.