### PR TITLE
Fix to return all installed DotNetSDK versions (v2)

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -124,14 +124,12 @@ namespace Microsoft.Build.Locator
             var outputString = string.Join(Environment.NewLine, lines);
 
             var matched = DotNetBasePathRegex.Match(outputString);
-            if (!matched.Success)
+            string basePath = null;
+            if (matched.Success)
             {
-                yield break; 
+                basePath = matched.Groups[1].Value.Trim();
+                yield return basePath;
             }
-            
-            var basePath = matched.Groups[1].Value.Trim();
-
-            yield return basePath; // We return the version in use at the front of the list in order to ensure FirstOrDefault always returns the version in use.
 
             var lineSdkIndex = lines.FindIndex(line => line.Contains("SDKs installed"));
 

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -117,11 +117,6 @@ namespace Microsoft.Build.Locator
                 yield break;
             }
 
-            if (process.HasExited)
-            {
-                yield break;
-            }
-
             process.BeginOutputReadLine();
 
             process.WaitForExit();


### PR DESCRIPTION
This PR supersedes #117.
It contains some improvements to #79 (Return all installed DotNetSDK).
 - Fix console output event handling 
   - Problem: if the "dotnet --info" process runs faster and completes before we subscribe to the output events we loose its output. And we also were checking if the process completes successfully before this [line](https://github.com/microsoft/MSBuildLocator/pull/79/files#diff-82450af61239e35c0ab2b9c2fae5c42392a4807ae063b89660e5fdc9fce46c8eR98) we were existing without the actual list of SDKs.
   - Fixes:
     - [Subscribe to output events before starting the process](https://github.com/microsoft/MSBuildLocator/commit/612874161eb9458131ecbc0faa750d80ad7df0f9)
     - [Don't exit if the process has already finished](https://github.com/microsoft/MSBuildLocator/commit/3243554c15e3c4353d7694e1e88a9d1ea5d17ebd)
 -  Fix to not require the base path to be present to return the full list of SDKs
    - Problem: the base path is not returned by "dotnet --info" if the required version (from global.json) is not found. Still, we could return the list of installed SDKs and let the caller method to decide whether or not to use the available SDKs.
     - Fix:  [if the base path is found return it, otherwise proceed to list the installed SDKs](https://github.com/microsoft/MSBuildLocator/commit/f0d37a7df3eac0d851d40b44e7e437430dd58026)