### PR TITLE
Update .NET Core Version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,10 +17,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning requires non-shallow checkout
-    - name: Setup .NET Core 2.0 runtime
+    - name: Setup .NET Core 2.1 runtime
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.0.x
+        dotnet-version: 2.1.x
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v1
       with:

--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net471;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1;net5.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
+++ b/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MSBuildLocator\key.snk</AssemblyOriginatorKeyFile>

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
     <DebugType>full</DebugType>
 
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
`netcoreapp2.0` is no longer supported. And no reason for the BuilderApp sample to be 4.71.