### PR TITLE
Enable all searches on any framework, with sane defaults

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-#if NETCOREAPP
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,7 +16,7 @@ namespace Microsoft.Build.Locator
         private static readonly Regex SdkRegex = new Regex(@"(\S+) \[(.*?)]$", RegexOptions.Multiline);
 
         public static VisualStudioInstance GetInstance(string dotNetSdkPath)
-        {            
+        {
             if (string.IsNullOrWhiteSpace(dotNetSdkPath))
             {
                 return null;
@@ -49,7 +47,7 @@ namespace Microsoft.Build.Locator
             {
                 return null;
             }
-            
+
             // Components of the SDK often have dependencies on the runtime they shipped with, including that several tasks that shipped
             // in the .NET 5 SDK rely on the .NET 5.0 runtime. Assuming the runtime that shipped with a particular SDK has the same version,
             // this ensures that we don't choose an SDK that doesn't work with the runtime of the chosen application. This is not guaranteed
@@ -68,7 +66,7 @@ namespace Microsoft.Build.Locator
         }
 
         public static IEnumerable<VisualStudioInstance> GetInstances(string workingDirectory)
-        {            
+        {
             foreach (var basePath in GetDotNetBasePaths(workingDirectory))
             {
                 var dotnetSdk = GetInstance(basePath);
@@ -80,13 +78,13 @@ namespace Microsoft.Build.Locator
         private static IEnumerable<string> GetDotNetBasePaths(string workingDirectory)
         {
             const string DOTNET_CLI_UI_LANGUAGE = nameof(DOTNET_CLI_UI_LANGUAGE);
-            
+
             Process process;
             var lines = new List<string>();
             try
             {
                 process = new Process()
-                { 
+                {
                     StartInfo = new ProcessStartInfo("dotnet", "--info")
                     {
                         WorkingDirectory = workingDirectory,
@@ -147,12 +145,12 @@ namespace Microsoft.Build.Locator
 
                     var version = sdkMatch.Groups[1].Value.Trim();
                     var path = sdkMatch.Groups[2].Value.Trim();
-                    
+
                     path = Path.Combine(path, version) + Path.DirectorySeparatorChar;
 
                     if (!path.Equals(basePath))
-                        paths.Add(path); 
-                                    
+                        paths.Add(path);
+
                     lineSdkIndex++;
                 }
             }
@@ -168,4 +166,3 @@ namespace Microsoft.Build.Locator
         }
     }
 }
-#endif

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Build.Locator
 
             AppDomain.CurrentDomain.AssemblyResolve += s_registeredHandler;
 #else
-            s_registeredHandler = (_, assemblyName) => 
+            s_registeredHandler = (_, assemblyName) =>
             {
                 return TryLoadAssembly(assemblyName);
             };
@@ -331,24 +331,26 @@ namespace Microsoft.Build.Locator
 
         private static IEnumerable<VisualStudioInstance> GetInstances(VisualStudioInstanceQueryOptions options)
         {
-#if NET46
-            var devConsole = GetDevConsoleInstance();
-            if (devConsole != null)
-                yield return devConsole;
+            if (options.DiscoveryTypes.HasFlag(DiscoveryType.DeveloperConsole))
+            {
+                var devConsole = GetDevConsoleInstance();
+                if (devConsole != null)
+                    yield return devConsole;
+            }
 
-    #if FEATURE_VISUALSTUDIOSETUP
-            foreach (var instance in VisualStudioLocationHelper.GetInstances())
-                yield return instance;
-    #endif
-#endif
+            if (options.DiscoveryTypes.HasFlag(DiscoveryType.VisualStudioSetup))
+            {
+                foreach (var instance in VisualStudioLocationHelper.GetInstances())
+                    yield return instance;
+            }
 
-#if NETCOREAPP
-            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory))
-                yield return dotnetSdk;
-#endif
+            if (options.DiscoveryTypes.HasFlag(DiscoveryType.DotNetSdk))
+            {
+                foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory))
+                    yield return dotnetSdk;
+            }
         }
 
-#if NET46
         private static VisualStudioInstance GetDevConsoleInstance()
         {
             var path = Environment.GetEnvironmentVariable("VSINSTALLDIR");
@@ -378,6 +380,5 @@ namespace Microsoft.Build.Locator
 
             return null;
         }
-#endif
     }
 }

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -16,13 +16,14 @@
     <Description>Package that assists in locating and using a copy of MSBuild installed as part of Visual Studio 2017 or higher or .NET Core SDK 2.1 or higher.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
-    <DefineConstants>$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.21" PrivateAssets="all" />
+  <ItemGroup>
+    <!-- These packages are only available on .NET Framework, but are solely there to call into a COM service and work fine on .NET Core -->
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="1.16.30" PrivateAssets="all">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.21" PrivateAssets="all">
+      <NoWarn>NU1701</NoWarn>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -16,10 +16,9 @@ namespace Microsoft.Build.Locator
         public static VisualStudioInstanceQueryOptions Default => new VisualStudioInstanceQueryOptions
         {
             DiscoveryTypes =
-#if FEATURE_VISUALSTUDIOSETUP
+#if NETFRAMEWORK
                 DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
-#endif
-#if NETCOREAPP
+#else
                 DiscoveryType.DotNetSdk
 #endif
         };

--- a/src/MSBuildLocator/VisualStudioLocationHelper.cs
+++ b/src/MSBuildLocator/VisualStudioLocationHelper.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // Taken from https://github.com/Microsoft/msbuild/blob/6851538897f5d7b08024a6d8435bc44be5869e53/src/Shared/VisualStudioLocationHelper.cs
 
-#if FEATURE_VISUALSTUDIOSETUP
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -112,4 +110,3 @@ namespace Microsoft.Build.Locator
             IntPtr reserved);
     }
 }
-#endif


### PR DESCRIPTION
This change enables apps running under .NET Core to find instances of VS/DevCmd prompt if needed. On .NET Framework, it allows searching for .NET Core. It does not change the defaults, though. 

Fixes #131