### PR TITLE
Prolong version check

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Build.Locator
                 if (File.Exists(msbuildExe))
                 {
                     FileVersionInfo ver = FileVersionInfo.GetVersionInfo(msbuildExe);
-                    if (ver.FileMajorPart < 17 || ver.FileMinorPart < 1)
+                    if (ver.FileMajorPart < 17 || (ver.FileMajorPart == 17 && ver.FileMinorPart < 1))
                     {
                         if (Path.GetDirectoryName(msbuildExe).EndsWith(@"\amd64", StringComparison.OrdinalIgnoreCase))
                         {

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -217,7 +217,8 @@ namespace Microsoft.Build.Locator
                 string msbuildExe = Path.Combine(path, "MSBuild.exe");
                 if (File.Exists(msbuildExe))
                 {
-                    if (FileVersionInfo.GetVersionInfo(msbuildExe).FileMajorPart < 17)
+                    FileVersionInfo ver = FileVersionInfo.GetVersionInfo(msbuildExe);
+                    if (ver.FileMajorPart < 17 || ver.FileMinorPart < 1)
                     {
                         if (Path.GetDirectoryName(msbuildExe).EndsWith(@"\amd64", StringComparison.OrdinalIgnoreCase))
                         {


### PR DESCRIPTION
The change in #135 was supposed to be made unnecessary by https://github.com/dotnet/msbuild/pull/6890, but apparently my setup is the only one that has dotnet.exe under both the dotnet folder and the sdks folder, so it didn't work. xen2 fixed the problem in https://github.com/dotnet/msbuild/pull/7013, but that won't get in 'til 17.1, so we need to prolong the version check here.