### PR TITLE
Bugfix: https://github.com/microsoft/MSBuildLocator/issues/176

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -314,9 +314,24 @@ namespace Microsoft.Build.Locator
             const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
             const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
 
-            Environment.SetEnvironmentVariable(MSBUILD_EXE_PATH, Path.Combine(dotNetSdkPath, "MSBuild.dll"));
-            Environment.SetEnvironmentVariable(MSBuildExtensionsPath, dotNetSdkPath);
-            Environment.SetEnvironmentVariable(MSBuildSDKsPath, Path.Combine(dotNetSdkPath, "Sdks"));
+            AddEnvFileVar(MSBUILD_EXE_PATH, Path.Combine(dotNetSdkPath, "MSBuild.dll"));
+            AddEnvDirVar(MSBuildExtensionsPath, dotNetSdkPath);
+            AddEnvDirVar(MSBuildSDKsPath, Path.Combine(dotNetSdkPath, "Sdks"));
+
+            void AddEnvDirVar(string name, string value)
+            {
+                if (Directory.Exists(value))
+                {
+                    Environment.SetEnvironmentVariable(name, value);
+                }
+            }
+            void AddEnvFileVar(string name, string value)
+            {
+                if (File.Exists(value))
+                {
+                    Environment.SetEnvironmentVariable(name, value);
+                }
+            }
         }
 
         private static bool IsMSBuildAssembly(Assembly assembly) => IsMSBuildAssembly(assembly.GetName());

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -314,17 +314,9 @@ namespace Microsoft.Build.Locator
             const string MSBuildExtensionsPath = nameof(MSBuildExtensionsPath);
             const string MSBuildSDKsPath = nameof(MSBuildSDKsPath);
 
-            var variables = new Dictionary<string, string>
-            {
-                [MSBUILD_EXE_PATH] = dotNetSdkPath + "MSBuild.dll",
-                [MSBuildExtensionsPath] = dotNetSdkPath,
-                [MSBuildSDKsPath] = dotNetSdkPath + "Sdks"
-            };
-
-            foreach (var kvp in variables)
-            {
-                Environment.SetEnvironmentVariable(kvp.Key, kvp.Value);
-            }
+            Environment.SetEnvironmentVariable(MSBUILD_EXE_PATH, Path.Combine(dotNetSdkPath, "MSBuild.dll"));
+            Environment.SetEnvironmentVariable(MSBuildExtensionsPath, dotNetSdkPath);
+            Environment.SetEnvironmentVariable(MSBuildSDKsPath, Path.Combine(dotNetSdkPath, "Sdks"));
         }
 
         private static bool IsMSBuildAssembly(Assembly assembly) => IsMSBuildAssembly(assembly.GetName());


### PR DESCRIPTION
closes: #176

dotNetSdkPath may not end with / or \ - we can't use simple concat