### PR TITLE
Use Path.Combine to build environment variables

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -316,9 +316,9 @@ namespace Microsoft.Build.Locator
 
             var variables = new Dictionary<string, string>
             {
-                [MSBUILD_EXE_PATH] = dotNetSdkPath + "MSBuild.dll",
+                [MSBUILD_EXE_PATH] = Path.Combine(dotNetSdkPath, "MSBuild.dll"),
                 [MSBuildExtensionsPath] = dotNetSdkPath,
-                [MSBuildSDKsPath] = dotNetSdkPath + "Sdks"
+                [MSBuildSDKsPath] = Path.Combine(dotNetSdkPath, "Sdks")
             };
 
             foreach (var kvp in variables)


### PR DESCRIPTION
Fixes #176 

As descibed in the issue it seems there are no trailing backslashes in some paths. To ensure proper paths in the environment variables I changed the string concatenation to a safer `Path.Combine`