### PR TITLE
Add MSBuildLocator.RegisterLatest method

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -104,6 +104,29 @@ namespace Microsoft.Build.Locator
         }
 
         /// <summary>
+        ///     Discover instances of Visual Studio and register the one with the highest version number. See <see cref="RegisterInstance" />.
+        /// </summary>
+        /// <returns>Instance of Visual Studio found and registered.</returns>
+        public static VisualStudioInstance RegisterLatest()
+        {
+            VisualStudioInstance instance = GetInstances(VisualStudioInstanceQueryOptions.Default)
+                .OrderByDescending(i => i.Version)
+                .FirstOrDefault();
+            if (instance == null)
+            {
+                var error = "No instances of MSBuild could be detected." +
+                            Environment.NewLine +
+                            $"Try calling {nameof(RegisterInstance)} or {nameof(RegisterMSBuildPath)} to manually register one.";
+
+                throw new InvalidOperationException(error);
+            }
+
+            RegisterInstance(instance);
+
+            return instance;
+        }
+
+        /// <summary>
         ///     Add assembly resolution for Microsoft.Build core dlls in the current AppDomain from the specified
         ///     instance of Visual Studio. See <see cref="QueryVisualStudioInstances()" /> to discover Visual Studio
         ///     instances or use <see cref="RegisterDefaults" />.


### PR DESCRIPTION
`MSBuildLocator.RegisterDefault()` is recommended by the Microsoft documentation but is problematic as it simply takes the `FirstOrDefault()` instance.

Exactly which instance is the `FirstOrDefault()` is not particularly clear to developers when there is more than once instance of Visual Studio installed on the computer.

Instances appear to be returned by the Visual Studio Setup API in alphabetical order, which is the order that Windows returns when enumerating the `C:\ProgramData\Microsoft\VisualStudio\Packages\_Instances` directory.

Therefore, the instance registered by `RegisterDefault()` is not neccesarily the oldest, nor the newest, nor the one that was installed first, nor the one that was installed most recently. Unless there is some determinism to the instance ID that I am not aware of, it appears to be randomly generated and thus entirely down to luck.

At my company we have a large number of machines with both VS2019 and VS2022, and can get inconsistent results across different identically-configured machines which can cause crashes and errors that are particularly difficult to diagnose. As a workaround, in some of our tools we have been manually registering the instance sorted by version number, to great success.

In this PR I have added a new method, `RegisterLatest()`, which enumerates all of the instances and registers the one with the highest version number. This will provide a far greater level of determinism and consistency, and gives the user some level of control over which version is actually selected.