### PR TITLE
Validate dotnet executable exists

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -102,14 +102,17 @@ namespace Microsoft.Build.Locator
                 string filePath = Path.Combine(dir, exeName);
                 if (File.Exists(Path.Combine(dir, exeName)))
                 {
-                    dotnetPath = filePath;
-                    break;
+                    dotnetPath = Path.GetDirectoryName(isWindows ? filePath : realpath(filePath) ?? filePath);
+                    if (File.Exists(dotnetPath))
+                    {
+                        break;
+                    }
                 }
             }
 
-            if (dotnetPath != null)
+            if (dotnetPath is null)
             {
-                dotnetPath = Path.GetDirectoryName(isWindows ? dotnetPath : realpath(dotnetPath) ?? dotnetPath);
+                throw new InvalidOperationException("Could not find the dotnet executable. Is it on the PATH?");
             }
 
             string bestSDK = null;

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Build.Locator
             foreach (string dir in Environment.GetEnvironmentVariable("PATH").Split(Path.PathSeparator))
             {
                 string filePath = Path.Combine(dir, exeName);
-                if (File.Exists(Path.Combine(dir, exeName)))
+                if (File.Exists(filePath))
                 {
                     filePath = Path.GetDirectoryName(isWindows ? filePath : realpath(filePath) ?? filePath);
                     if (File.Exists(Path.Combine(filePath, exeName)))

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -102,12 +102,17 @@ namespace Microsoft.Build.Locator
                 string filePath = Path.Combine(dir, exeName);
                 if (File.Exists(filePath))
                 {
-                    filePath = Path.GetDirectoryName(isWindows ? filePath : realpath(filePath) ?? filePath);
-                    if (File.Exists(Path.Combine(filePath, exeName)))
+                    if (!isWindows)
                     {
-                        dotnetPath = filePath;
-                        break;
+                        filePath = realpath(filePath) ?? filePath;
+                        if (!File.Exists(filePath))
+                        {
+                            continue;
+                        }
                     }
+
+                    dotnetPath = Path.GetDirectoryName(filePath);
+                    break;
                 }
             }
 

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -102,9 +102,10 @@ namespace Microsoft.Build.Locator
                 string filePath = Path.Combine(dir, exeName);
                 if (File.Exists(Path.Combine(dir, exeName)))
                 {
-                    dotnetPath = Path.GetDirectoryName(isWindows ? filePath : realpath(filePath) ?? filePath);
-                    if (File.Exists(dotnetPath))
+                    filePath = Path.GetDirectoryName(isWindows ? filePath : realpath(filePath) ?? filePath);
+                    if (File.Exists(Path.Combine(filePath, exeName)))
                     {
+                        dotnetPath = filePath;
                         break;
                     }
                 }


### PR DESCRIPTION
Fixes #201

If a user has a symlink called dotnet (or dotnet.exe on Windows) on their PATH, but that symlink points to a file that does not exist, we will find that symlink, stop processing the path, and ultimately fail. We should notice that the symlink target does not exist and continue processing PATH, only failing if we fail to find an executable anywhere on the PATH.