### PR TITLE
Use dotnet from current process if possible

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Build.Locator
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             string exeName = isWindows ? "dotnet.exe" : "dotnet";
 
-            if (Process.GetCurrentProcess().ProcessName.Equals(exeName))
+            if (Process.GetCurrentProcess().ProcessName.Equals("dotnet"))
             {
                 // We're already in a dotnet process! Use it.
                 dotnetPath = Process.GetCurrentProcess().MainModule.FileName;


### PR DESCRIPTION
If we are running in a dotnet executable, we should use that instead of trying to find it on the PATH.