### PR TITLE
Make Unregister a no-op Fixes #77

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -290,19 +290,6 @@ namespace Microsoft.Build.Locator
         /// </remarks>
         public static void Unregister()
         {
-            if (!IsRegistered)
-            {
-                var error = $"{typeof(MSBuildLocator)}.{nameof(Unregister)} was called, but no MSBuild instance is registered." + Environment.NewLine +
-                            $"Ensure that {nameof(RegisterInstance)}, {nameof(RegisterMSBuildPath)}, or {nameof(RegisterDefaults)} is called before calling this method." + Environment.NewLine +
-                            $"{nameof(IsRegistered)} should be used to determine whether calling {nameof(Unregister)} is a valid operation.";
-                throw new InvalidOperationException(error);
-            }
-
-#if NET46
-            AppDomain.CurrentDomain.AssemblyResolve -= s_registeredHandler;
-#else
-            AssemblyLoadContext.Default.Resolving -= s_registeredHandler;
-#endif
         }
 
         /// <summary>

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -283,11 +283,8 @@ namespace Microsoft.Build.Locator
         }
 
         /// <summary>
-        ///     Remove assembly resolution previously registered via <see cref="RegisterInstance" />, <see cref="RegisterMSBuildPath" />, or <see cref="RegisterDefaults" />.
+        ///     This has no effect and exists only for backwards compatibility. Calling it is unnecessary.
         /// </summary>
-        /// <remarks>
-        ///     This will automatically be called once all supported assemblies are loaded into the current AppDomain and so generally is not necessary to call directly.
-        /// </remarks>
         public static void Unregister()
         {
         }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.ComponentModel;
 
 #if NETCOREAPP
 using System.Runtime.Loader;
@@ -285,6 +286,7 @@ namespace Microsoft.Build.Locator
         /// <summary>
         ///     This has no effect and exists only for backwards compatibility. Calling it is unnecessary.
         /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public static void Unregister()
         {
         }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -3,12 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using System.ComponentModel;
 
 #if NETCOREAPP
 using System.Runtime.Loader;


### PR DESCRIPTION
Unregister currently looks to see if we had previously registered MSBuild, and if so, it undoes our resolver but leaves IsRegistered set to true. This basically means we can't unregister then re-register it, at least not via MSBuildLocator. One fix could be ensuring that IsRegistered is set to false at the end of Unregister, but since we no longer register specific assemblies anyway, making it a no-op seems more reasonable. There's no need to unregister anyway.