### PR TITLE
Allow finding Visual Studio installs on Windows on .NET 6+.

### DIFF
--- a/samples/BuilderApp/BuilderApp.csproj
+++ b/samples/BuilderApp/BuilderApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
+++ b/src/MSBuildLocator.Tests/Microsoft.Build.Locator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\MSBuildLocator\key.snk</AssemblyOriginatorKeyFile>

--- a/src/MSBuildLocator.Tests/QueryInstanceTests.cs
+++ b/src/MSBuildLocator.Tests/QueryInstanceTests.cs
@@ -3,7 +3,9 @@
 
 using Shouldly;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
+
 
 namespace Microsoft.Build.Locator.Tests
 {
@@ -22,5 +24,29 @@ namespace Microsoft.Build.Locator.Tests
             instance.DiscoveryType.ShouldNotBe(DiscoveryType.DotNetSdk);
 #endif
         }
+
+#if NETCOREAPP
+        [Fact]
+        public void MultipleInstancesTest()
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            if (!isWindows)
+            {
+                return;
+            }
+            var queryOptions = new VisualStudioInstanceQueryOptions
+            {
+                DiscoveryTypes = DiscoveryType.VisualStudioSetup | DiscoveryType.DotNetSdk,
+            };
+            var instances = MSBuildLocator.QueryVisualStudioInstances(queryOptions).ToList();
+
+            // We should have at least one VS install and at least one .NET SDK install.
+            instances
+                .Select(inst => inst.DiscoveryType)
+                .Distinct()
+                .Count()
+                .ShouldBe(2);
+        }
+#endif
     }
 }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -356,16 +356,12 @@ namespace Microsoft.Build.Locator
 
         private static IEnumerable<VisualStudioInstance> GetInstances(VisualStudioInstanceQueryOptions options)
         {
-#if NET46
             var devConsole = GetDevConsoleInstance();
             if (devConsole != null)
                 yield return devConsole;
 
-    #if FEATURE_VISUALSTUDIOSETUP
             foreach (var instance in VisualStudioLocationHelper.GetInstances())
                 yield return instance;
-    #endif
-#endif
 
 #if NETCOREAPP
             foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory))
@@ -373,7 +369,6 @@ namespace Microsoft.Build.Locator
 #endif
         }
 
-#if NET46
         private static VisualStudioInstance GetDevConsoleInstance()
         {
             var path = Environment.GetEnvironmentVariable("VSINSTALLDIR");
@@ -403,6 +398,5 @@ namespace Microsoft.Build.Locator
 
             return null;
         }
-#endif
     }
 }

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net46;net6.0</TargetFrameworks>
     <DebugType>full</DebugType>
 
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
@@ -16,11 +16,7 @@
     <Description>Package that assists in locating and using a copy of MSBuild installed as part of Visual Studio 2017 or higher or .NET Core SDK 2.1 or higher.</Description>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
-    <DefineConstants>$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>
-  </PropertyGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net46'">
+  <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.3.2180" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.21" PrivateAssets="all" />
   </ItemGroup>

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -16,11 +16,10 @@ namespace Microsoft.Build.Locator
         public static VisualStudioInstanceQueryOptions Default => new VisualStudioInstanceQueryOptions
         {
             DiscoveryTypes =
-#if FEATURE_VISUALSTUDIOSETUP
-                DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
-#endif
 #if NETCOREAPP
                 DiscoveryType.DotNetSdk
+#else
+                DiscoveryType.DeveloperConsole | DiscoveryType.VisualStudioSetup
 #endif
         };
 

--- a/src/MSBuildLocator/VisualStudioLocationHelper.cs
+++ b/src/MSBuildLocator/VisualStudioLocationHelper.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // Taken from https://github.com/Microsoft/msbuild/blob/6851538897f5d7b08024a6d8435bc44be5869e53/src/Shared/VisualStudioLocationHelper.cs
 
-#if FEATURE_VISUALSTUDIOSETUP
-
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -112,4 +110,3 @@ namespace Microsoft.Build.Locator
             IntPtr reserved);
     }
 }
-#endif


### PR DESCRIPTION
This is a very important use-case for me, because the .NET SDKs can't process `.vcxproj` files but Visual Studio can, so being unable to locate Visual Studio build tools at all means I can't run my app on .NET. I think it makes sense to change this given that the readme file explicitly talks about it not being enough to load some projects, so allowing more users to load more projects seems to fit with the project's ethos.

I've tested this on Windows, and it works perfectly for my use-case. Unfortunately I don't have access to other supported .NET platforms, but I'm fairly confident it'll work correctly - `GetDevConsoleInstance` has all the APIs available but will certainly return `null`, and `VisualStudioLocationHelper.GetInstances` will catch a `DllNotFoundException` and continue, so the end result should be the same.