### PR TITLE
add setting "DOTNET_HOST_PATH" to environment variables

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -211,6 +211,8 @@ namespace Microsoft.Build.Locator
                 throw new InvalidOperationException("Could not find the dotnet executable. Is it set on the DOTNET_ROOT?");
             }
 
+            SetEnvironmentVariableIfEmpty("DOTNET_HOST_PATH", dotnetPath);
+
             return dotnetPath;
         }
 
@@ -283,6 +285,14 @@ namespace Microsoft.Build.Locator
             string? dotnetPath = Environment.GetEnvironmentVariable(environmentVariable);
             
             return string.IsNullOrEmpty(dotnetPath) ? null : ValidatePath(dotnetPath);
+        }
+
+        private static void SetEnvironmentVariableIfEmpty(string name, string value)
+        {
+            if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(name)))
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
         }
 
         private static string? ValidatePath(string dotnetPath)


### PR DESCRIPTION
Fixes: https://github.com/microsoft/MSBuildLocator/issues/229

Background: SDK sets [DOTNET_HOST_PATH](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-environment-variables#dotnet_host_path) before launching app - incl MSBuild.exe
When using custom apphost - this won't be set. So MSBuildLocator should set this to have that variable available in MSBuild