### PR TITLE
Fix hostfx resolving issue in some Mac machines

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -170,7 +170,12 @@ namespace Microsoft.Build.Locator
 
                     if (File.Exists(hostFxrAssembly))
                     {
-                        return NativeLibrary.TryLoad(hostFxrAssembly, out var handle) ? handle : IntPtr.Zero;
+                        if (NativeLibrary.TryLoad(hostFxrAssembly, out var handle))
+                        {
+                            return handle;
+                        }
+
+                        Console.Error.WriteLine($"'{hostFxrAssembly}' cannot be loaded.");
                     }
                     else
                     {

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -131,8 +131,6 @@ namespace Microsoft.Build.Locator
 
         private static IntPtr HostFxrResolver(Assembly assembly, string libraryName)
         {
-            Console.Error.WriteLine($"Try to load native library {libraryName}");
-
             string hostFxrLibName = "libhostfxr";
             string libExtension = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "dylib" : "so";
 

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Build.Locator
             var libExtension = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? "dylib" : "so";
 
             // the DllImport hardcoded the name as hostfxr.
-            if (!hostFxrLibName.Equals(libraryName, StringComparison.Ordinal) && !libraryName.Equals("hostfxr", StringComparison.Ordinal))
+            if (!hostFxrLibName.Equals(libraryName, StringComparison.OrdinalIgnoreCase) && !libraryName.Equals("hostfxr", StringComparison.OrdinalIgnoreCase))
             {
                 return IntPtr.Zero;
             }
@@ -206,7 +206,7 @@ namespace Microsoft.Build.Locator
             {
                 string? dotnetExePath = GetCurrentProcessPath();
                 var isRunFromDotnetExecutable = !string.IsNullOrEmpty(dotnetExePath) 
-                    && Path.GetFileName(dotnetExePath).Equals(ExeName, StringComparison.InvariantCultureIgnoreCase);
+                    && Path.GetFileName(dotnetExePath).Equals(ExeName, StringComparison.OrdinalIgnoreCase);
                 
                 if (isRunFromDotnetExecutable)
                 {

--- a/src/MSBuildLocator/NativeMethods.cs
+++ b/src/MSBuildLocator/NativeMethods.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Build.Locator
 {
     internal class NativeMethods
     {
+        internal const string HostFxrName = "hostfxr";
+
         internal enum hostfxr_resolve_sdk2_flags_t
         {
             disallow_prerelease = 0x1,
@@ -30,14 +32,14 @@ namespace Microsoft.Build.Locator
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
                 string[] value);
 
-        [DllImport("hostfxr", CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int hostfxr_resolve_sdk2(
             string exe_dir,
             string working_dir,
             hostfxr_resolve_sdk2_flags_t flags,
             hostfxr_resolve_sdk2_result_fn result);
 
-        [DllImport("hostfxr", CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        [DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int hostfxr_get_available_sdks(string exe_dir, hostfxr_get_available_sdks_result_fn result);
 
         [DllImport("libc", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]

--- a/src/MSBuildLocator/Utils/SemanticVersion.cs
+++ b/src/MSBuildLocator/Utils/SemanticVersion.cs
@@ -74,8 +74,7 @@ namespace Microsoft.Build.Locator
         /// </summary>
         public int CompareTo(SemanticVersion other)
         {
-            var comparer = new VersionComparer();
-            return comparer.Compare(this, other);
+            return VersionComparer.Compare(this, other);
         }
     }
 }

--- a/src/MSBuildLocator/Utils/VersionComparer.cs
+++ b/src/MSBuildLocator/Utils/VersionComparer.cs
@@ -6,17 +6,17 @@ using System.Collections.Generic;
 
 namespace Microsoft.Build.Locator
 {
-    internal sealed class VersionComparer 
+    internal static class VersionComparer 
     {
         /// <summary>
         /// Determines if both versions are equal.
         /// </summary>
-        public bool Equals(SemanticVersion x, SemanticVersion y) => Compare(x, y) == 0;
+        public static bool Equals(SemanticVersion x, SemanticVersion y) => Compare(x, y) == 0;
 
         /// <summary>
         /// Compare versions.
         /// </summary>
-        public int Compare(SemanticVersion x, SemanticVersion y)
+        public static int Compare(SemanticVersion x, SemanticVersion y)
         {
             if (Object.ReferenceEquals(x, y))
             {


### PR DESCRIPTION
This PR is to fix hostfx resolver issue on some Mac machines. There are a few issues fixed in this PR:

 1, the libraryName is actually the string from DllImport metadata, so it would be hostfxr
 2, enumerate directory will get a list of full path, the semantic version parser doesn't seem to handle it.
 3, DOTNET_HOST_PATH is actually path to the dotnet command file, which is different from DOTNET_ROOT, that was a misunderstanding in the code which leads it to set it incorrectly.

This PR is to address:

https://github.com/dotnet/msbuild/issues/9038
