### PR TITLE
Update the place for AllowQueryAllRuntimeVersions

### DIFF
--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -12,6 +11,8 @@ using System.Text;
 
 #if NETCOREAPP
 using System.Runtime.Loader;
+#else
+using System.Diagnostics;
 #endif
 
 namespace Microsoft.Build.Locator
@@ -42,14 +43,6 @@ namespace Microsoft.Build.Locator
         ///     Gets a value indicating whether an instance of MSBuild is currently registered.
         /// </summary>
         public static bool IsRegistered => s_registeredHandler != null;
-
-        /// <summary>
-        ///     Allow discovery of .NET SDK versions that are unlikely to be successfully loaded in the current process.
-        /// </summary>
-        /// <remarks>
-        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if your application has special logic to handle loading an incompatible SDK, such as launching a new process with the target SDK's runtime.
-        /// </remarks.
-        public static bool AllowQueryAllRuntimeVersions { get; set; } = false;
 
         /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild can be registered.
@@ -361,7 +354,7 @@ namespace Microsoft.Build.Locator
 #endif
 
 #if NETCOREAPP
-            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, AllowQueryAllRuntimeVersions))
+            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, options.AllowQueryAllRuntimeVersions))
                 yield return dotnetSdk;
 #endif
         }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -45,6 +45,14 @@ namespace Microsoft.Build.Locator
         public static bool IsRegistered => s_registeredHandler != null;
 
         /// <summary>
+        ///     Allow discovery of .NET SDK versions that are unlikely to be successfully loaded in the current process.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if your application has special logic to handle loading an incompatible SDK, such as launching a new process with the target SDK's runtime.
+        /// </remarks.
+        public static bool AllowQueryAllRuntimeVersions { get; set; } = false;
+
+        /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild can be registered.
         /// </summary>
         /// <remarks>
@@ -347,14 +355,16 @@ namespace Microsoft.Build.Locator
             if (devConsole != null)
                 yield return devConsole;
 
-    #if FEATURE_VISUALSTUDIOSETUP
+#if FEATURE_VISUALSTUDIOSETUP
             foreach (var instance in VisualStudioLocationHelper.GetInstances())
                 yield return instance;
-    #endif
+#endif
 #endif
 
 #if NETCOREAPP
-            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, options.AllowQueryAllRuntimeVersions))
+            // AllowAllRuntimeVersions was added to VisualStudioInstanceQueryOptions for fulfilling Roslyn's needs. One of the properties will be removed in v2.0.
+            bool allowAllRuntimeVersions = AllowQueryAllRuntimeVersions || options.AllowAllRuntimeVersions;
+            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, allowAllRuntimeVersions))
                 yield return dotnetSdk;
 #endif
         }

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.9.2164" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.10.63" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net46'">
-    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.10.63" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="3.9.2164" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK.EmbedInteropTypes" Version="15.0.36" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Locator
         /// <remarks>
         ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if your application has special logic to handle loading an incompatible SDK, such as launching a new process with the target SDK's runtime.
         /// </remarks.
-        public bool AllowQueryAllRuntimeVersions { get; set; } = false;
+        public bool AllowAllRuntimeVersions { get; set; } = false;
 #endif
 
         /// <summary>

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -29,6 +29,16 @@ namespace Microsoft.Build.Locator
         /// </summary>
         public DiscoveryType DiscoveryTypes { get; set; }
 
+#if NETCOREAPP
+        /// <summary>
+        ///     Allow discovery of .NET SDK versions that are unlikely to be successfully loaded in the current process.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if your application has special logic to handle loading an incompatible SDK, such as launching a new process with the target SDK's runtime.
+        /// </remarks.
+        public bool AllowQueryAllRuntimeVersions { get; set; } = false;
+#endif
+
         /// <summary>
         ///     Working directory to use when querying for instances. Ensure it is the project directory to pick up the right global.json.
         /// </summary>


### PR DESCRIPTION
## Fixes

No functional changes, just update the place of the flag AllowQueryAllRuntimeVersions in order to address the Roslyn's team needs. See https://github.com/microsoft/MSBuildLocator/pull/265#discussion_r1498227732 for more details.
