### PR TITLE
Build with .NET SDK 8 in PR builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,13 +24,13 @@ jobs:
           6.0.x
           8.0.x
     - name: Restore
-      run: dotnet restore -bl:restore.binlog
+      run: dotnet restore -bl:LocatorRestore.binlog
     - name: Build
       run: dotnet build --no-restore -bl:MSBuildLocator.binlog
     - name: Test
       run: dotnet test --no-build --verbosity normal
     - name: Pack
-      run: dotnet pack --no-build
+      run: dotnet pack --no-build --configuration Debug -bl:LocatorPack.binlog
     - name: Upload Packages
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,6 +22,7 @@ jobs:
       with:
         dotnet-version: |
           6.0.x
+          8.0.x
     - name: Restore
       run: dotnet restore -bl:restore.binlog
     - name: Build


### PR DESCRIPTION
This will more closely match the official build ("latest included-in-VS SDK").

Leaving 6.0.x in the list because we'll need that runtime for tests.