### PR TITLE
Return SDKs from all dotnet location

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -101,10 +101,7 @@ namespace Microsoft.Build.Locator
                     }
 
                     // Only add an SDK once, even if it's installed in multiple locations.
-                    if (!versionInstanceMap.ContainsKey(dotnetSdk.Version))
-                    {
-                        versionInstanceMap.Add(dotnetSdk.Version, dotnetSdk);
-                    }
+                    versionInstanceMap.TryAdd(dotnetSdk.Version, dotnetSdk);
                 }
             }
 

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Build.Locator
                 discoveryType: DiscoveryType.DotNetSdk);
         }
 
-        public static IEnumerable<VisualStudioInstance> GetInstances(string workingDirectory, bool allowQueryAllRuntimes)
+        public static IEnumerable<VisualStudioInstance> GetInstances(string workingDirectory, bool allowQueryAllRuntimes, bool allowAllDotnetLocations)
         {
             string? bestSdkPath;
             string[] allAvailableSdks;
@@ -79,7 +79,7 @@ namespace Microsoft.Build.Locator
                 AddUnmanagedDllResolver();
 
                 bestSdkPath = GetSdkFromGlobalSettings(workingDirectory);
-                allAvailableSdks = GetAllAvailableSDKs().ToArray();
+                allAvailableSdks = GetAllAvailableSDKs(allowAllDotnetLocations).ToArray();
             }
             finally
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Build.Locator
             }
 
             // Returns the list of all available SDKs ordered by ascending version.
-            static IEnumerable<string> GetAllAvailableSDKs()
+            static IEnumerable<string> GetAllAvailableSDKs(bool allowAllDotnetLocations)
             {
                 bool foundSdks = false;
                 string[]? resolvedPaths = null;
@@ -131,6 +131,11 @@ namespace Microsoft.Build.Locator
                         foreach (string path in resolvedPaths)
                         {
                             yield return path;
+                        }
+
+                        if (resolvedPaths.Length > 0 && !allowAllDotnetLocations)
+                        {
+                            break;
                         }
                     }
                 }

--- a/src/MSBuildLocator/MSBuildLocator.cs
+++ b/src/MSBuildLocator/MSBuildLocator.cs
@@ -53,6 +53,14 @@ namespace Microsoft.Build.Locator
         public static bool AllowQueryAllRuntimeVersions { get; set; } = false;
 
         /// <summary>
+        ///     Allow discovery of .NET SDK versions from all discovered dotnet install locations.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if you do not mind behaving differently than the dotnet muxer.
+        /// </remarks.
+        public static bool AllowQueryAllDotnetLocations { get; set; } = false;
+
+        /// <summary>
         ///     Gets a value indicating whether an instance of MSBuild can be registered.
         /// </summary>
         /// <remarks>
@@ -200,7 +208,7 @@ namespace Microsoft.Build.Locator
             {
                 if (string.IsNullOrWhiteSpace(msbuildSearchPaths[i]))
                 {
-                    nullOrWhiteSpaceExceptions.Add(new ArgumentException($"Value at position {i+1} may not be null or whitespace", nameof(msbuildSearchPaths)));
+                    nullOrWhiteSpaceExceptions.Add(new ArgumentException($"Value at position {i + 1} may not be null or whitespace", nameof(msbuildSearchPaths)));
                 }
             }
             if (nullOrWhiteSpaceExceptions.Count > 0)
@@ -266,7 +274,7 @@ namespace Microsoft.Build.Locator
 
             AppDomain.CurrentDomain.AssemblyResolve += s_registeredHandler;
 #else
-            s_registeredHandler = (_, assemblyName) => 
+            s_registeredHandler = (_, assemblyName) =>
             {
                 return TryLoadAssembly(assemblyName);
             };
@@ -377,7 +385,8 @@ namespace Microsoft.Build.Locator
 #if NETCOREAPP
             // AllowAllRuntimeVersions was added to VisualStudioInstanceQueryOptions for fulfilling Roslyn's needs. One of the properties will be removed in v2.0.
             bool allowAllRuntimeVersions = AllowQueryAllRuntimeVersions || options.AllowAllRuntimeVersions;
-            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, allowAllRuntimeVersions))
+            bool allowAllDotnetLocations = AllowQueryAllDotnetLocations || options.AllowAllDotnetLocations;
+            foreach (var dotnetSdk in DotNetSdkLocationHelper.GetInstances(options.WorkingDirectory, allowAllRuntimeVersions, allowAllDotnetLocations))
                 yield return dotnetSdk;
 #endif
         }
@@ -404,7 +413,7 @@ namespace Microsoft.Build.Locator
                     Version.TryParse(versionString, out version);
                 }
 
-                if(version != null)
+                if (version != null)
                 {
                     return new VisualStudioInstance("DEVCONSOLE", path, version, DiscoveryType.DeveloperConsole);
                 }

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -37,6 +37,14 @@ namespace Microsoft.Build.Locator
         ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if your application has special logic to handle loading an incompatible SDK, such as launching a new process with the target SDK's runtime.
         /// </remarks.
         public bool AllowAllRuntimeVersions { get; set; } = false;
+
+        /// <summary>
+        ///     Allow discovery of .NET SDK versions from all discovered dotnet install locations.
+        /// </summary>
+        /// <remarks>
+        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if you do not mind behaving differently than the dotnet muxer.
+        /// </remarks.
+        public bool AllowAllDotnetLocations { get; set; } = false;
 #endif
 
         /// <summary>

--- a/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
+++ b/src/MSBuildLocator/VisualStudioInstanceQueryOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Locator
         ///     Allow discovery of .NET SDK versions from all discovered dotnet install locations.
         /// </summary>
         /// <remarks>
-        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if you do not mind behaving differently than the dotnet muxer.
+        ///     Defaults to <see langword="false"/>. Set this to <see langword="true"/> only if you do not mind behaving differently than a command-line dotnet invocation.
         /// </remarks.
         public bool AllowAllDotnetLocations { get; set; } = false;
 #endif

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7",
+  "version": "1.8",
   "assemblyVersion": "1.0.0.0",
   "publicReleaseRefSpec": [
     "^refs/heads/release/.*"


### PR DESCRIPTION
[Review with whitespace off](https://github.com/microsoft/MSBuildLocator/pull/329/files?diff=split&w=1) as the formatter removed trailing whitespace.

The method which finds all SDKs has an early exit which stops it from finding SDKs from more than one dotnet install. This PR removes the early exit and filters the returned instances by their reported version number. This should deduplicate the SDKs.