### PR TITLE
Auto-generate binding redirects only when targeting .NET Framework.

### DIFF
--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.props
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.props
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <AutoGenerateBindingRedirects Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes the immediate cause of dotnet/fsharp#18924.