### PR TITLE
Modernize `DotNetSdkLocationHelper` and `hostfxr` interop.

### DIFF
--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Build.Locator
             {
                 if (!IsWindows)
                 {
-                    hostPath = realpath(hostPath) ?? hostPath;
+                    hostPath = File.ResolveLinkTarget(hostPath, true)?.FullName ?? hostPath;
                 }
 
                 AddIfValid(Path.GetDirectoryName(hostPath));
@@ -314,19 +314,6 @@ namespace Microsoft.Build.Locator
             return dotnetPath;
         }
 
-        /// <summary>
-        /// This native method call determines the actual location of path, including
-        /// resolving symbolic links.
-        /// </summary>
-        private static string? realpath(string path)
-        {
-            IntPtr ptr = NativeMethods.realpath(path, IntPtr.Zero);
-            string? result = Marshal.PtrToStringAuto(ptr);
-            NativeMethods.free(ptr);
-
-            return result;
-        }
-
         private static string? FindDotnetPathFromEnvVariable(string environmentVariable)
         {
             string? dotnetPath = Environment.GetEnvironmentVariable(environmentVariable);
@@ -349,7 +336,7 @@ namespace Microsoft.Build.Locator
             {
                 if (!IsWindows)
                 {
-                    fullPathToDotnetFromRoot = realpath(fullPathToDotnetFromRoot) ?? fullPathToDotnetFromRoot;
+                    fullPathToDotnetFromRoot = File.ResolveLinkTarget(fullPathToDotnetFromRoot, true)?.FullName ?? fullPathToDotnetFromRoot;
                     return File.Exists(fullPathToDotnetFromRoot) ? Path.GetDirectoryName(fullPathToDotnetFromRoot) : null;
                 }
 

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -116,10 +116,9 @@ namespace Microsoft.Build.Locator
             static IEnumerable<string> GetAllAvailableSDKs(bool allowAllDotnetLocations)
             {
                 bool foundSdks = false;
-                string[]? resolvedPaths = null;
                 foreach (string dotnetPath in s_dotnetPathCandidates.Value)
                 {
-                    int rc = NativeMethods.hostfxr_get_available_sdks(exe_dir: dotnetPath, result: (key, value) => resolvedPaths = value);
+                    int rc = NativeMethods.hostfxr_get_available_sdks(exe_dir: dotnetPath, out string[]? resolvedPaths);
 
                     if (rc == 0 && resolvedPaths != null)
                     {
@@ -150,13 +149,7 @@ namespace Microsoft.Build.Locator
                 string? resolvedSdk = null;
                 foreach (string dotnetPath in s_dotnetPathCandidates.Value)
                 {
-                    int rc = NativeMethods.hostfxr_resolve_sdk2(exe_dir: dotnetPath, working_dir: workingDirectory, flags: 0, result: (key, value) =>
-                    {
-                        if (key == NativeMethods.hostfxr_resolve_sdk2_result_key_t.resolved_sdk_dir)
-                        {
-                            resolvedSdk = value;
-                        }
-                    });
+                    int rc = NativeMethods.hostfxr_resolve_sdk2(exe_dir: dotnetPath, working_dir: workingDirectory, flags: 0, out resolvedSdk, out _);
 
                     if (rc == 0)
                     {

--- a/src/MSBuildLocator/DotNetSdkLocationHelper.cs
+++ b/src/MSBuildLocator/DotNetSdkLocationHelper.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Build.Locator
         [GeneratedRegex(@"^(\d+)\.(\d+)\.(\d+)", RegexOptions.Multiline)]
         private static partial Regex VersionRegex();
 
-        private static readonly string ExeName = OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
-        private static readonly Lazy<IList<string>> s_dotnetPathCandidates = new(() => ResolveDotnetPathCandidates());
+        private static string ExeName => OperatingSystem.IsWindows() ? "dotnet.exe" : "dotnet";
+        private static readonly Lazy<List<string>> s_dotnetPathCandidates = new(() => ResolveDotnetPathCandidates());
 
         public static VisualStudioInstance? GetInstance(string dotNetSdkPath, bool allowQueryAllRuntimeVersions)
         {
@@ -231,12 +231,12 @@ namespace Microsoft.Build.Locator
 
         private static string SdkResolutionExceptionMessage(string methodName) => $"Failed to find all versions of .NET Core MSBuild. Call to {methodName}. There may be more details in stderr.";
 
-        private static IList<string> ResolveDotnetPathCandidates()
+        private static List<string> ResolveDotnetPathCandidates()
         {
             var pathCandidates = new List<string>();
             AddIfValid(GetDotnetPathFromROOT());
 
-            string? dotnetExePath = GetCurrentProcessPath();
+            string? dotnetExePath = Environment.ProcessPath;
             bool isRunFromDotnetExecutable = !string.IsNullOrEmpty(dotnetExePath)
                 && Path.GetFileName(dotnetExePath).Equals(ExeName, StringComparison.InvariantCultureIgnoreCase);
 
@@ -282,8 +282,6 @@ namespace Microsoft.Build.Locator
 
             return dotnetPath;
         }
-
-        private static string? GetCurrentProcessPath() => Environment.ProcessPath;
 
         private static string? GetDotnetPathFromPATH()
         {

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net46;net8.0</TargetFrameworks>

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFrameworks>net46;net8.0</TargetFrameworks>
@@ -14,6 +14,7 @@
     <PackageTags>msbuildlocator;locator;buildlocator</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>1.6.1</PackageValidationBaselineVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net46'">
     <DefineConstants>$(DefineConstants);FEATURE_VISUALSTUDIOSETUP</DefineConstants>

--- a/src/MSBuildLocator/NativeMethods.cs
+++ b/src/MSBuildLocator/NativeMethods.cs
@@ -41,11 +41,5 @@ namespace Microsoft.Build.Locator
 
         [DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int hostfxr_get_available_sdks(string exe_dir, hostfxr_get_available_sdks_result_fn result);
-
-        [DllImport("libc", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr realpath(string path, IntPtr buffer);
-
-        [DllImport("libc", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern void free(IntPtr ptr);
     }
 }

--- a/src/MSBuildLocator/NativeMethods.cs
+++ b/src/MSBuildLocator/NativeMethods.cs
@@ -60,8 +60,6 @@ namespace Microsoft.Build.Locator
         [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
         private static unsafe void hostfxr_resolve_sdk2_callback(hostfxr_resolve_sdk2_result_key_t key, void* value)
         {
-            Debug.Assert(t_resolve_sdk2_resolved_sdk_dir is null);
-            Debug.Assert(t_resolve_sdk2_global_json_path is null);
             string str = AutoStringMarshaller.ConvertToManaged(value);
             switch (key)
             {

--- a/src/MSBuildLocator/NativeMethods.cs
+++ b/src/MSBuildLocator/NativeMethods.cs
@@ -1,12 +1,16 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#if NETCOREAPP
 using System;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.Marshalling;
 
 namespace Microsoft.Build.Locator
 {
-    internal class NativeMethods
+    internal partial class NativeMethods
     {
         internal const string HostFxrName = "hostfxr";
 
@@ -15,31 +19,97 @@ namespace Microsoft.Build.Locator
             disallow_prerelease = 0x1,
         };
 
-        internal enum hostfxr_resolve_sdk2_result_key_t
+        private enum hostfxr_resolve_sdk2_result_key_t
         {
             resolved_sdk_dir = 0,
             global_json_path = 1,
         };
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        internal delegate void hostfxr_resolve_sdk2_result_fn(
-                hostfxr_resolve_sdk2_result_key_t key,
-                string value);
+        internal static int hostfxr_resolve_sdk2(string exe_dir, string working_dir, hostfxr_resolve_sdk2_flags_t flags, out string resolved_sdk_dir, out string global_json_path)
+        {
+            Debug.Assert(t_resolve_sdk2_resolved_sdk_dir is null);
+            Debug.Assert(t_resolve_sdk2_global_json_path is null);
+            try
+            {
+                unsafe
+                {
+                    int result = hostfxr_resolve_sdk2(exe_dir, working_dir, flags, &hostfxr_resolve_sdk2_callback);
+                    resolved_sdk_dir = t_resolve_sdk2_resolved_sdk_dir;
+                    global_json_path = t_resolve_sdk2_global_json_path;
+                    return result;
+                }
+            }
+            finally
+            {
+                t_resolve_sdk2_resolved_sdk_dir = null;
+                t_resolve_sdk2_global_json_path = null;
+            }
+        }
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        internal delegate void hostfxr_get_available_sdks_result_fn(
-                hostfxr_resolve_sdk2_result_key_t key,
-                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
-                string[] value);
-
-        [DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int hostfxr_resolve_sdk2(
+        [LibraryImport(HostFxrName, StringMarshalling = StringMarshalling.Utf16)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe partial int hostfxr_resolve_sdk2(
             string exe_dir,
             string working_dir,
             hostfxr_resolve_sdk2_flags_t flags,
-            hostfxr_resolve_sdk2_result_fn result);
+            delegate* unmanaged[Cdecl]<hostfxr_resolve_sdk2_result_key_t, ushort*, void> result);
 
-        [DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern int hostfxr_get_available_sdks(string exe_dir, hostfxr_get_available_sdks_result_fn result);
+        [ThreadStatic]
+        private static string t_resolve_sdk2_resolved_sdk_dir, t_resolve_sdk2_global_json_path;
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe void hostfxr_resolve_sdk2_callback(hostfxr_resolve_sdk2_result_key_t key, ushort* value)
+        {
+            Debug.Assert(t_resolve_sdk2_resolved_sdk_dir is null);
+            Debug.Assert(t_resolve_sdk2_global_json_path is null);
+            string str = Utf16StringMarshaller.ConvertToManaged(value);
+            switch (key)
+            {
+                case hostfxr_resolve_sdk2_result_key_t.resolved_sdk_dir:
+                    t_resolve_sdk2_resolved_sdk_dir = str;
+                    break;
+                case hostfxr_resolve_sdk2_result_key_t.global_json_path:
+                    t_resolve_sdk2_global_json_path = str;
+                    break;
+            }
+        }
+
+        internal static int hostfxr_get_available_sdks(string exe_dir, out string[] sdks)
+        {
+            Debug.Assert(t_get_available_sdks_result is null);
+            try
+            {
+                unsafe
+                {
+                    int result = hostfxr_get_available_sdks(exe_dir, &hostfxr_get_available_sdks_callback);
+                    sdks = t_get_available_sdks_result;
+                    return result;
+                }
+            }
+            finally
+            {
+                t_get_available_sdks_result = null;
+            }
+        }
+
+        //[DllImport(HostFxrName, CharSet = CharSet.Auto, ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        [LibraryImport(HostFxrName, StringMarshalling = StringMarshalling.Utf16)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe partial int hostfxr_get_available_sdks(string exe_dir, delegate* unmanaged[Cdecl]<int, ushort**, void> result);
+
+        [ThreadStatic]
+        private static string[] t_get_available_sdks_result;
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe void hostfxr_get_available_sdks_callback(int count, ushort** sdks)
+        {
+            string[] result = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                result[i] = Utf16StringMarshaller.ConvertToManaged(sdks[i]);
+            }
+            t_get_available_sdks_result = result;
+        }
     }
 }
+#endif


### PR DESCRIPTION
* The `NativeMethods` class was updated to use the P/Invoke source generator, and `[UnmanagedCallersOnly]`. The changes made are in a similar vein to dotnet/runtime#119034.
* The `DotNetSdkLocationHelper` class was updated to use APIs added in newer frameworks, like the regex source generator, or APIs to resolve symlinks. The latter also lets us remove the P/Invokes to `libc`.