### PR TITLE
Fix hostfxr_get_available_sdks_result_fn array size type.

### DIFF
--- a/src/MSBuildLocator/NativeMethods.cs
+++ b/src/MSBuildLocator/NativeMethods.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Locator
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
         internal delegate void hostfxr_get_available_sdks_result_fn(
-                hostfxr_resolve_sdk2_result_key_t key,
+                int sdk_count,
                 [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)]
                 string[] value);
 


### PR DESCRIPTION
This changes the array size type to 'int' so it matches the 'int32_t' native type.

This was typed as an enum.
The enum type is accepted by CoreCLR.
Mono throws a MarshalDirectiveException because it requires the array size to be an integral type.

Fixes https://github.com/dotnet/msbuild/issues/12570.

@rainersigwald ptal

cc @jkotas @medhatiwari @giritrivedi