### PR TITLE
Add StringTools to do-not-deploy list

### DIFF
--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -14,7 +14,8 @@
             '%(PackageReference.Identity)' == 'Microsoft.Build.Runtime' or
             '%(PackageReference.Identity)' == 'Microsoft.Build.Localization' or
             '%(PackageReference.Identity)' == 'Microsoft.Build.Engine' or
-            '%(PackageReference.Identity)' == 'Microsoft.NET.StringTools'
+            '%(PackageReference.Identity)' == 'Microsoft.NET.StringTools' or
+            '%(PackageReference.Identity)' == 'NuGet.Frameworks'
           )"/>
     </ItemGroup>
     <Error


### PR DESCRIPTION
An internal tool recently had trouble updating to .NET 10 because
it deployed a stale local copy of `Microsoft.NET.StringTools.dll` that
was working (by coincidence) throughout .NET 9 but failed after
dotnet/msbuild#12100 added some API surface to StringTools and used it.

Partial fix for #353.
