### PR TITLE
Update release pipeline to download artifacts

### DIFF
--- a/release-pipeline.yml
+++ b/release-pipeline.yml
@@ -8,7 +8,6 @@ resources:
       enabled: false
 
 variables:
-  SymbolsAgentPath: '$(System.DefaultWorkingDirectory)\_$(Build.DefinitionName)\Symbols'
   SymbolsFeatureName: 'MSBuild'
   SymbolsProject: 'DDE'
   TeamName: 'msbuild'
@@ -23,12 +22,16 @@ stages:
     pool:
       name: 'VSEngSS-MicroBuild2022-1ES'
     steps:
+    - download: microsoft_MSBuildLocator
+      displayName: 'Download Symbols Artifact'
+      artifact: Symbols
+
     - task: MicroBuildArchiveSymbols@6
       displayName: 'Archive $(SymbolsFeatureName) on Symweb'
       inputs:
         SymbolsFeatureName: '$(SymbolsFeatureName)'
         SymbolsProject: '$(SymbolsProject)'
-        SymbolsAgentPath: '$(SymbolsAgentPath)'
+        SymbolsAgentPath: '$(Pipeline.Workspace)/microsoft_MSBuildLocator/Symbols'
         SubmitToInternet: true
         ExpirationInDays: '5475'
         azureSubscription: 'VSEng-SymbolsUpload'
@@ -52,6 +55,9 @@ stages:
     pool:
       name: 'VSEngSS-MicroBuild2022-1ES'
     steps:
+    - download: microsoft_MSBuildLocator
+      displayName: 'Download NuGet Package Artifact'
+      artifact: pkg
     - task: NuGetCommand@2
       displayName: 'NuGet push'
       inputs:


### PR DESCRIPTION
The current version fails due to missed symbols.
https://dev.azure.com/devdiv/DevDiv/DevDiv%20Team/_build/results?buildId=12732798&view=logs&j=2a5dc928-90a4-5c98-d5c7-694cfffe901e&t=bae38a6f-67c2-5092-ce03-4c4a49376a3a&l=28

Apparently, it's not downloaded automatically, Project system does the same thing https://github.com/dotnet/project-system/blob/c69d77d38ed38c4d4334b0affea10d2448f52875/eng/pipelines/templates/publish-symbols.yml#L58