### PR TITLE
Make the MSBuild runtime assembly check more correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ That additional build logic is distributed with Visual Studio, with Visual Studi
 
 Loading MSBuild from Visual Studio also ensures that your application gets the same view of projects as `MSBuild.exe`, `dotnet build`, or Visual Studio, including bug fixes, feature additions, and performance improvements that may come from a newer MSBuild release.
 
-## How Locator searches for .NET SDK?
+## How does Locator search for the .NET SDK?
 
 MSBuild.Locator searches for the locally installed SDK based on the following priority:
 

--- a/docs/diagnostics/MSBL001.md
+++ b/docs/diagnostics/MSBL001.md
@@ -1,0 +1,66 @@
+# MSBL001 - MSBuild runtime package is referenced without Runtime Assets excluded
+
+## Error Message
+
+> A PackageReference to the package '{PackageId}' at version '{Version}' is present in this project without ExcludeAssets="runtime" set. This can cause errors at run-time due to MSBuild assembly-loading.
+
+## Cause
+
+This error occurs when your project references MSBuild NuGet packages (such as `Microsoft.Build`, `Microsoft.Build.Framework`, `Microsoft.Build.Utilities.Core`, etc.) without excluding their runtime assets. When you use Microsoft.Build.Locator, you want MSBuildLocator to load MSBuild assemblies from an installed Visual Studio or .NET SDK instance, not from the NuGet packages in your output directory.
+
+## Why This Is a Problem
+
+When MSBuild runtime assemblies are copied to your application's output directory, your application may load these assemblies instead of the MSBuild installation that MSBuildLocator registered. This can lead to several runtime issues:
+
+1. **Assembly version conflicts**: Your application loads MSBuild assemblies from your output directory while MSBuildLocator tries to load from a different MSBuild installation
+2. **Missing SDKs and build logic**: The MSBuild assemblies in your output directory don't include the SDKs, targets, and build logic needed to build real projects
+3. **Inconsistent behavior**: Your application may behave differently than `MSBuild.exe`, `dotnet build`, or Visual Studio when evaluating projects
+
+## Example Runtime Error
+
+Without `ExcludeAssets="runtime"`, you may encounter errors like:
+
+```
+System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Build, Version=15.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies.
+```
+
+Or:
+
+```
+System.InvalidOperationException: SDK 'Microsoft.NET.Sdk' could not be resolved. The SDK resolver "Microsoft.DotNet.MSBuildSdkResolver" returned null.
+```
+
+This happens because your application loads MSBuild assemblies from your bin folder (e.g., version 15.5.180) while MSBuildLocator has registered a different MSBuild installation (e.g., version 17.0) to use at runtime. The .NET runtime gets confused about which assemblies to use, leading to version conflicts and missing dependencies.
+
+## Solution
+
+Add `ExcludeAssets="runtime"` to all MSBuild PackageReferences in your project file:
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+  <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+  <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
+  ...
+</ItemGroup>
+```
+
+This tells NuGet to use these packages only for compilation, not at runtime. At runtime, MSBuildLocator will load MSBuild assemblies from the registered Visual Studio or .NET SDK installation.
+
+## Alternative: Disable the Check (Not Recommended)
+
+If you need to distribute MSBuild assemblies with your application (not recommended), you can disable this check by setting the following property in your project file:
+
+```xml
+<PropertyGroup>
+  <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
+</PropertyGroup>
+```
+
+**Warning**: Disabling this check means you must distribute all of MSBuild and its associated toolset with your application, which is generally not recommended. The MSBuild team does not support this scenario, and you may encounter issues with SDK resolution and build logic.
+
+## Related Documentation
+
+- [Use Microsoft.Build.Locator](https://learn.microsoft.com/visualstudio/msbuild/updating-an-existing-application#use-microsoftbuildlocator)
+- [MSBuildLocator on GitHub](https://github.com/microsoft/MSBuildLocator)
+

--- a/src/MSBuildLocator/Microsoft.Build.Locator.csproj
+++ b/src/MSBuildLocator/Microsoft.Build.Locator.csproj
@@ -12,6 +12,7 @@
     <Title>MSBuild Locator</Title>
     <Description>Package that assists in locating and using a copy of MSBuild installed as part of Visual Studio 2017 or higher or .NET Core SDK 2.1 or higher.</Description>
     <PackageTags>msbuildlocator;locator;buildlocator</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>1.6.1</PackageValidationBaselineVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -25,14 +26,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MicroBuild.Core" Version="0.3.0" PrivateAssets="all" />
-    <Content Include="build\Microsoft.Build.Locator.props">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-      <PackagePath>build\</PackagePath>
-    </Content>
-    <Content Include="build\Microsoft.Build.Locator.targets">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-      <PackagePath>build\</PackagePath>
-    </Content>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="build\Microsoft.Build.Locator.props" Pack="true" PackagePath="build\" />
+    <None Include="build\Microsoft.Build.Locator.targets" Pack="true" PackagePath="build\" />
+    <None Include="build\Microsoft.Build.Locator.props" Pack="true" PackagePath="buildTransitive/" />
+    <None Include="build\Microsoft.Build.Locator.targets" Pack="true" PackagePath="buildTransitive/" />
   </ItemGroup>
   <ItemGroup>
     <FilesToSign Include="$(OutDir)\Microsoft.Build.Locator.dll">

--- a/src/MSBuildLocator/README.md
+++ b/src/MSBuildLocator/README.md
@@ -1,0 +1,57 @@
+# Microsoft.Build.Locator
+
+Microsoft.Build.Locator helps you locate and register MSBuild assemblies provided with Visual Studio or the .NET SDK. This is essential when you need to use MSBuild APIs in your application to evaluate or build projects.
+
+## Why do I need this?
+
+When using MSBuild's .NET API to load and build projects, you need access to the SDKs and build logic distributed with Visual Studio or the .NET SDK, not just the MSBuild APIs. MSBuildLocator helps you find these installations and set up your application to use them, ensuring your code gets the same view of projects as `MSBuild.exe`, `dotnet build`, or Visual Studio.
+
+## Quick Start
+
+Before using any MSBuild APIs, register MSBuild assemblies:
+
+```csharp
+using Microsoft.Build.Locator;
+using Microsoft.Build.Evaluation;
+
+// Register defaults before using any MSBuild types
+MSBuildLocator.RegisterDefaults();
+
+// Now you can safely use MSBuild APIs.
+// NOTE: due the the way that the CLR loads assemblies, you MUST
+//       register MSBuild through Locator before any types from 
+//       the MSBuild assemblies are used in your application.
+//       The safest way to ensure this is to put any MSBuild API
+//       access into a separate method.
+LoadProject();
+
+void LoadProject()
+{
+  var project = new Project("MyProject.csproj");
+  ...
+}
+```
+
+For more control over which MSBuild instance to use:
+
+```csharp
+using Microsoft.Build.Locator;
+
+// Query available MSBuild instances
+var instances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
+
+// Register a specific instance
+var instance = instances.OrderByDescending(i => i.Version).First();
+MSBuildLocator.RegisterInstance(instance);
+```
+
+## Documentation
+
+For complete documentation, see [Use Microsoft.Build.Locator](https://learn.microsoft.com/visualstudio/msbuild/updating-an-existing-application#use-microsoftbuildlocator) on Microsoft Learn.
+
+## Samples
+
+See the [BuilderApp](https://github.com/microsoft/MSBuildLocator/blob/a349ee7ffd889cd7634d3fd8b413bf9f29244b50/samples/BuilderApp) sample for a full
+exploration of the MSBuildLocator library and capabilities.
+
+

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -14,11 +14,12 @@
       <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'NuGet.Frameworks'))" />
       <MSBuildAssembliesCopyLocalItems Include="@(_MSBuildAssembliesCopyLocalItems->WithMetadataValue('CopyLocal', 'true')->WithMetadataValue('AssetType', 'runtime'))" />
       <_DistinctMSBuildPackagesReferencedPoorly Include="@(MSBuildAssembliesCopyLocalItems->Metadata('NuGetPackageId')->Distinct())" />
-      <_DistinctPackagesWithVersions Include="@(_DistinctMSBuildPackagesReferencedPoorly->'%(NuGetPackageId)@%(NuGetPackageVersion)')" />
     </ItemGroup>
 
     <Error
-      Condition="@(_DistinctPackagesWithVersions->Count()) > 0"
-      Text="A PackageReference to an MSBuild run-time package without ExcludeAssets=&quot;runtime&quot; exists in your project. This will cause MSBuild run-time assemblies to be copied to your output directory, causing your application to load them at runtime. To use the copy of MSBuild registered by MSBuildLocator, set ExcludeAssets=&quot;runtime&quot; on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildAssemblyCopyCheck=true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(_DistinctPackagesWithVersions, ', ')" />
+      Code="MSBL001"
+      Text="A PackageReference to the package '%(_DistinctMSBuildPackagesReferencedPoorly.NuGetPackageId)' at version '%(_DistinctMSBuildPackagesReferencedPoorly.NuGetPackageVersion)' is present in this project without ExcludeAssets=&quot;runtime&quot; set. This can cause errors at run-time due to MSBuild assembly-loading."
+      HelpLink="https://aka.ms/msbuild/locator/diagnostics/MSBL001"
+      />
   </Target>
 </Project>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -1,25 +1,24 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Target Name="EnsureMSBuildAssembliesNotCopied" AfterTargets="Build" Condition="'$(DisableMSBuildAssemblyCopyCheck)' != 'true'">
+  <Target Name="EnsureMSBuildAssembliesNotCopied" AfterTargets="ResolvePackageAssets" Condition="'$(DisableMSBuildAssemblyCopyCheck)' != 'true'">
     <ItemGroup>
-      <MSBuildPackagesWithoutPrivateAssets
-        Include="@(PackageReference)"
-        Condition="!$([MSBuild]::ValueOrDefault('%(PackageReference.ExcludeAssets)', '').ToLower().Contains('runtime')) and
-          (
-            '%(PackageReference.Identity)' == 'Microsoft.Build' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Framework' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Utilities.Core' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Tasks.Core' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Engine' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Conversion.Core' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Runtime' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Localization' or
-            '%(PackageReference.Identity)' == 'Microsoft.Build.Engine' or
-            '%(PackageReference.Identity)' == 'Microsoft.NET.StringTools' or
-            '%(PackageReference.Identity)' == 'NuGet.Frameworks'
-          )"/>
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Framework'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Utilities.Core'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Tasks.Core'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Engine'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Conversion.Core'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Runtime'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Localization'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.Build.Engine'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'Microsoft.NET.StringTools'))" />
+      <_MSBuildAssembliesCopyLocalItems Include="@(RuntimeCopyLocalItems->WithMetadataValue('NuGetPackageId', 'NuGet.Frameworks'))" />
+      <MSBuildAssembliesCopyLocalItems Include="@(_MSBuildAssembliesCopyLocalItems->WithMetadataValue('CopyLocal', 'true')->WithMetadataValue('AssetType', 'runtime'))" />
+      <_DistinctMSBuildPackagesReferencedPoorly Include="@(MSBuildAssembliesCopyLocalItems->Metadata('NuGetPackageId')->Distinct())" />
+      <_DistinctPackagesWithVersions Include="@(_DistinctMSBuildPackagesReferencedPoorly->'%(NuGetPackageId)@%(NuGetPackageVersion)')" />
     </ItemGroup>
+
     <Error
-      Condition="'@(MSBuildPackagesWithoutPrivateAssets)' != ''"
-      Text="A PackageReference to Microsoft.Build.* without ExcludeAssets=&quot;runtime&quot; exists in your project. This will cause MSBuild assemblies to be copied to your output directory, causing your application to load them at runtime. To use the copy of MSBuild registered by MSBuildLocator, set ExcludeAssets=&quot;runtime&quot; on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildAssemblyCopyCheck=true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(MSBuildPackagesWithoutPrivateAssets)" />
+      Condition="@(_DistinctPackagesWithVersions->Count()) > 0"
+      Text="A PackageReference to an MSBuild run-time package without ExcludeAssets=&quot;runtime&quot; exists in your project. This will cause MSBuild run-time assemblies to be copied to your output directory, causing your application to load them at runtime. To use the copy of MSBuild registered by MSBuildLocator, set ExcludeAssets=&quot;runtime&quot; on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildAssemblyCopyCheck=true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: @(_DistinctPackagesWithVersions, ', ')" />
   </Target>
 </Project>

--- a/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
+++ b/src/MSBuildLocator/build/Microsoft.Build.Locator.targets
@@ -17,6 +17,7 @@
     </ItemGroup>
 
     <Error
+      Condition="@(_DistinctMSBuildPackagesReferencedPoorly->Count()) > 0"
       Code="MSBL001"
       Text="A PackageReference to the package '%(_DistinctMSBuildPackagesReferencedPoorly.NuGetPackageId)' at version '%(_DistinctMSBuildPackagesReferencedPoorly.NuGetPackageVersion)' is present in this project without ExcludeAssets=&quot;runtime&quot; set. This can cause errors at run-time due to MSBuild assembly-loading."
       HelpLink="https://aka.ms/msbuild/locator/diagnostics/MSBL001"


### PR DESCRIPTION
While debugging test failures in https://github.com/CommunityToolkit/Aspire/pull/949 with @aaronpowell we discovered that the [Microsoft.SqlServer.DacFx package](https://www.nuget.org/packages/Microsoft.SqlServer.DacFx/170.2.70#dependencies-body-tab) includes a dependency on Microsoft.Build that seems to be causing MSbuild runtime dlls to end up in the test project!

This is very likely an authoring error that we should track down with them, but what surprised me was that the check for the RuntimeAssets=exclude provided by this library didn't flag this. On further investigation I discovered two gaps in the check:

* it didn't cover transitive PackageReferences to the MSBuild runtime packages from the project referencing locator
* it didn't cause the check to happen on projects that depend on the project referencing locator

The Aspire scenario is

* Package with MSBuild references (Microsoft.SqlServer.DacFx)
* is referenced by a library package that references Locator (so those MSBuild deps are transitive deps to this project, and not found)
* which is referenced by a test app project (so the check doesn't run on this project _and_ those transitive deps would not be found even if it did)

To fix this, we need to do two things
* make the check more correct by checking the runtime assets of the project in question after ResolvePackageReferences
  *  this fixes the 'transitive packageref' problem
* also ship the check as a `buildTransitive` check
  * this fixes the 'locator is referenced by a lib that is then referenced by an app' problem

Given this lib (`dotnet new classlib`):

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net10.0</TargetFramework>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="Microsoft.Build.Locator" Version="1.10.11-ga349ee7ffd" />
    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.2.70" />
  </ItemGroup>

</Project>
```

and this test project referencing the lib (`dotnet new mstest`):

```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net10.0</TargetFramework>
    <LangVersion>latest</LangVersion>
    <ImplicitUsings>enable</ImplicitUsings>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <ItemGroup>
    <PackageReference Include="MSTest" Version="4.0.1" />
  </ItemGroup>

  <ItemGroup>
    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
  </ItemGroup>

  <ItemGroup>
    <ProjectReference Include="..\lib\lib.csproj" />
  </ItemGroup>

</Project>
```

Building the `test` project does now trigger our error:

```
> dotnet build -bl
Restore complete (0.3s)
  test net10.0 failed with 1 error(s) (0.0s)
    /Users/chethusk/.nuget/packages/microsoft.build.locator/1.10.11-ga349ee7ffd/buildTransitive/Microsoft.Build.Locator.targets(19,5): error A PackageReference to an MSBuild run-time package without ExcludeAssets="runtime" exists in your project. This will cause MSBuild run-time assemblies to be copied to your output directory, causing your application to load them at runtime. To use the copy of MSBuild registered by MSBuildLocator, set ExcludeAssets="runtime" on the MSBuild PackageReferences. To disable this check, set the property DisableMSBuildAssemblyCopyCheck=true in your project file (not recommended as you must distributed all of MSBuild + associated toolset). Package(s) referenced: Microsoft.Build@15.9.20, Microsoft.Build.Framework@15.9.20, Microsoft.Build.Utilities.Core@15.9.20
```

While in here, I also added a small README for the package so that the NuGet.org experience is nicer.