### PR TITLE
Modernize CI: update to latest .NET SDK and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily" # until we settle into a cadence
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning requires non-shallow checkout
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: |
           8.0.x
@@ -32,13 +32,13 @@ jobs:
     - name: Pack
       run: dotnet pack --no-build --configuration Debug -bl:LocatorPack.binlog
     - name: Upload Packages
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: package
         path: '**/*.*nupkg'
         if-no-files-found: error
     - name: Upload logs
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: ${{ always() }}
       with:
         name: logs

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: Build and test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     branches: 
       - main
@@ -14,15 +14,15 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning requires non-shallow checkout
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: |
-          6.0.x
           8.0.x
+          10.0.x
     - name: Restore
       run: dotnet restore -bl:LocatorRestore.binlog
     - name: Build

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning requires non-shallow checkout
     - name: Setup .NET SDK

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,6 +17,7 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0 # Nerdbank.GitVersioning requires non-shallow checkout
+        persist-credentials: false
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:


### PR DESCRIPTION
## Summary

Modernizes the GitHub Actions CI pipeline to current versions and fixes some staleness that had crept in.

## Changes

**`.github/workflows/pull-request.yml`**
- Bump `actions/checkout@v2` -> `@v6` and `actions/setup-dotnet@v1` -> `@v5`
- Install the latest .NET 10 SDK (`10.0.x`); keep `8.0.x` (required to run the `net8.0` test target) and drop the EOL `6.0.x`
- Fix the stale `push` trigger branch `master` -> `main` to match the repo's default branch

**`.github/dependabot.yml`**
- Add the `github-actions` package ecosystem (weekly) so action versions stay current automatically going forward