### PR TITLE
Use VS stable MicroBuild pool for official build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,12 +20,12 @@ extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@CustomPipelineTemplates
   parameters:
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
       demands:
       - msbuild
     sdl:
       sourceAnalysisPool:
-        name: VSEngSS-MicroBuild2022-1ES
+        name: VSEng-MicroBuildVSStable
       policheck:
         enabled: true
       tsa:

--- a/release-pipeline.yml
+++ b/release-pipeline.yml
@@ -24,7 +24,7 @@ extends:
     settings:
       networkIsolationPolicy: Permissive,CFSClean
     pool:
-      name: VSEngSS-MicroBuild2022-1ES  
+      name: VSEng-MicroBuildVSStable
     stages:
     - stage: RetainBuild
       displayName: 'Retain build'


### PR DESCRIPTION
Updates the official Azure DevOps build to use the `VSEng-MicroBuildVSStable` pool.