### PR TITLE
Avoid unnecessary restore when running tests in PR builds

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -bl:MSBuildLocator.binlog
     - name: Test
-      run: dotnet test --no-restore --no-build --verbosity normal
+      run: dotnet vstest src\MSBuildLocator.Tests\bin\Debug\net472\Microsoft.Build.Locator.Tests.dll src\MSBuildLocator.Tests\bin\Debug\net8.0\Microsoft.Build.Locator.Tests.dll --logger:"console;verbosity=normal"
     - name: Pack
       run: dotnet pack --no-build --configuration Debug -bl:LocatorPack.binlog
     - name: Upload Packages

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -bl:MSBuildLocator.binlog
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-restore --no-build --verbosity normal
     - name: Pack
       run: dotnet pack --no-build --configuration Debug -bl:LocatorPack.binlog
     - name: Upload Packages


### PR DESCRIPTION
Honestly `dotnet test --no-build` should imply `--no-restore` . . .