### PR TITLE
Unify artifact-upload scans

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ extends:
       jobs:
       - job: job
         templateContext:
+          outputParentDirectory: '$(Build.ArtifactStagingDirectory)'
           outputs:
           - output: pipelineArtifact
             displayName: 'Upload Symbols Artifact'


### PR DESCRIPTION
In the last official build, running the many scans cost almost 7 minutes of build time. Doing it once should help dramatically. Same trick as in https://github.com/dotnet/msbuild/pull/12931.